### PR TITLE
fix: update home page meta tags and fix event sharing OpenGraph

### DIFF
--- a/src/app/(frontend)/(participant)/events/[id]/page.tsx
+++ b/src/app/(frontend)/(participant)/events/[id]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const supabase = await createClient();
   const { data: event } = await supabase
     .from("events")
-    .select("title, description, type")
+    .select("title, description, type, cover_image_url, date, location")
     .eq("id", id)
     .single();
 
@@ -35,6 +35,10 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     ? event.description.slice(0, 160)
     : `Join this ${typeLabels[event.type] || event.type} adventure on EventTara!`;
 
+  const images = event.cover_image_url
+    ? [{ url: event.cover_image_url, width: 1200, height: 630, alt: event.title }]
+    : undefined;
+
   return {
     title: event.title,
     description,
@@ -42,11 +46,15 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
       title: event.title,
       description,
       type: "article",
+      siteName: "EventTara",
+      url: `/events/${id}`,
+      ...(images && { images }),
     },
     twitter: {
       card: "summary_large_image",
       title: event.title,
       description,
+      ...(images && { images }),
     },
   };
 }

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -8,6 +8,18 @@ import EventCarousel from "@/components/events/EventCarousel";
 import HeroCarousel from "@/components/landing/HeroCarousel";
 import HostEventLink from "@/components/landing/HostEventLink";
 
+export const metadata = {
+  title: "EventTara — Outdoor Adventure Events in Panay Island",
+  description:
+    "Discover hiking, trail running, mountain biking, and road cycling events across Panay Island. From the mountains of Igbaras and Tubungan to the coasts of Antique — find your next adventure on EventTara.",
+  openGraph: {
+    title: "EventTara — Outdoor Adventure Events in Panay Island",
+    description:
+      "Discover hiking, trail running, mountain biking, and road cycling events across Panay Island. Find your next adventure on EventTara.",
+    type: "website" as const,
+  },
+};
+
 export const revalidate = 60;
 
 const categories = [


### PR DESCRIPTION
## Summary
- Add custom metadata to home page with Panay Island-focused title and description (was inheriting generic root layout defaults)
- Fix event sharing by adding `images` (cover image), `siteName`, and `url` to OpenGraph/Twitter metadata so social platforms render rich previews

## Test plan
- [x] `npm run build` passes
- [ ] Share home page link — preview shows updated title/description
- [ ] Share event link on social platform — preview shows event cover image, title, and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)