### PR TITLE
fix: rewrite Payload media URLs to static files for Vercel

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,13 +25,21 @@ const nextConfig = {
     ],
   },
   async rewrites() {
-    if (!supabaseUrl) return [];
-    return [
+    /** @type {import('next').Rewrite[]} */
+    const rules = [
+      // Payload CMS media: serve from public/media/ instead of Payload API
       {
-        source: "/storage/:path*",
-        destination: `${supabaseUrl}/storage/v1/object/public/:path*`,
+        source: "/api/media/file/:path*",
+        destination: "/media/:path*",
       },
     ];
+    if (supabaseUrl) {
+      rules.push({
+        source: "/storage/:path*",
+        destination: `${supabaseUrl}/storage/v1/object/public/:path*`,
+      });
+    }
+    return rules;
   },
   async headers() {
     return [


### PR DESCRIPTION
Payload CMS generates media URLs as /api/media/file/{filename} which fails on Vercel (500) because the serverless function can't read from public/media/. Added a Next.js rewrite to serve these from the static /media/ path instead.