### PR TITLE
feat: add contact us page with email form

### DIFF
--- a/src/app/(frontend)/(participant)/contact/page.tsx
+++ b/src/app/(frontend)/(participant)/contact/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+export default function ContactPage() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus("submitting");
+    setErrorMsg("");
+
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, message }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to send message.");
+      }
+
+      setStatus("success");
+      setName("");
+      setEmail("");
+      setMessage("");
+    } catch (error: any) {
+      setStatus("error");
+      setErrorMsg(error.message || "Something went wrong. Please try again.");
+    }
+  }
+
+  return (
+    <main className="py-20 bg-gray-50 dark:bg-slate-900 min-h-screen">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="text-4xl sm:text-5xl font-heading font-bold text-gray-900 dark:text-white mb-4">
+          Contact Us
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-10">
+          Have a question, suggestion, or just want to say hi? We&apos;d love to hear from you.
+        </p>
+
+        {status === "success" ? (
+          <div className="rounded-xl bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 p-6 text-center">
+            <h2 className="text-xl font-semibold text-green-800 dark:text-green-300 mb-2">
+              Message Sent!
+            </h2>
+            <p className="text-green-700 dark:text-green-400">
+              Thanks for reaching out. We&apos;ll get back to you as soon as we can.
+            </p>
+            <button
+              onClick={() => setStatus("idle")}
+              className="mt-4 text-sm font-medium text-green-600 dark:text-green-400 hover:underline"
+            >
+              Send another message
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <Input
+              id="name"
+              label="Name"
+              placeholder="Your name"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <Input
+              id="email"
+              label="Email"
+              type="email"
+              placeholder="you@example.com"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <div className="space-y-1">
+              <label
+                htmlFor="message"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Message
+              </label>
+              <textarea
+                id="message"
+                rows={5}
+                placeholder="How can we help?"
+                required
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                className="w-full px-4 py-3 rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:border-lime-500 focus:ring-2 focus:ring-lime-200 dark:focus:ring-lime-800 outline-none transition-colors resize-vertical"
+              />
+            </div>
+
+            {status === "error" && <p className="text-sm text-red-500">{errorMsg}</p>}
+
+            <Button type="submit" size="lg" disabled={status === "submitting"}>
+              {status === "submitting" ? "Sending..." : "Send Message"}
+            </Button>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/(frontend)/api/contact/route.ts
+++ b/src/app/(frontend)/api/contact/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { sendEmail } from "@/lib/email/send";
+import { contactInquiryHtml } from "@/lib/email/templates/contact-inquiry";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { name, email, message } = body;
+
+    if (!name || !email || !message) {
+      return NextResponse.json(
+        { error: "Name, email, and message are required." },
+        { status: 400 },
+      );
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json({ error: "Invalid email address." }, { status: 400 });
+    }
+
+    const result = await sendEmail({
+      to: "info@eventtara.com",
+      subject: `Contact Form: ${name}`,
+      html: contactInquiryHtml({ name, email, message }),
+      replyTo: email,
+    });
+
+    if (!result.success) {
+      return NextResponse.json({ error: "Failed to send message." }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Something went wrong." }, { status: 500 });
+  }
+}

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -402,6 +402,25 @@ export default async function Home() {
           </Link>
         </div>
       </section>
+
+      {/* Contact CTA */}
+      <section className="py-20 bg-white dark:bg-slate-800">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl sm:text-4xl font-heading font-bold text-gray-900 dark:text-white mb-4">
+            Have Questions?
+          </h2>
+          <p className="text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-2xl mx-auto">
+            Whether you need help with an event, have a partnership idea, or just want to say hello
+            — we&apos;re here for you.
+          </p>
+          <Link
+            href="/contact"
+            className="inline-flex items-center justify-center font-semibold rounded-xl text-lg py-4 px-8 bg-lime-500 hover:bg-lime-400 text-slate-900 transition-colors"
+          >
+            Contact Us
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -31,6 +31,7 @@ export default async function Footer() {
       links: [
         { label: "Host Your Event", url: "/signup?role=organizer" },
         { label: "Organizer Dashboard", url: "/dashboard" },
+        { label: "Contact Us", url: "/contact" },
       ],
     },
   ];

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -16,9 +16,10 @@ interface SendEmailOptions {
   to: string | string[];
   subject: string;
   html: string;
+  replyTo?: string;
 }
 
-export async function sendEmail({ to, subject, html }: SendEmailOptions) {
+export async function sendEmail({ to, subject, html, replyTo }: SendEmailOptions) {
   const resend = getResend();
 
   // Skip sending if no API key is configured
@@ -36,6 +37,7 @@ export async function sendEmail({ to, subject, html }: SendEmailOptions) {
       to: Array.isArray(to) ? to : [to],
       subject,
       html,
+      ...(replyTo && { replyTo }),
     });
 
     if (error) {

--- a/src/lib/email/templates/contact-inquiry.ts
+++ b/src/lib/email/templates/contact-inquiry.ts
@@ -1,0 +1,75 @@
+interface ContactInquiryProps {
+  name: string;
+  email: string;
+  message: string;
+}
+
+export function contactInquiryHtml({ name, email, message }: ContactInquiryProps): string {
+  const escapedMessage = message.replaceAll("\n", "<br />");
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>New Contact Inquiry</title>
+</head>
+<body style="margin:0;padding:0;background-color:#faf5f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#faf5f0;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background: linear-gradient(135deg, #0891b2, #0e7490);padding:32px;text-align:center;">
+              <h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:700;">EventTara</h1>
+              <p style="color:rgba(255,255,255,0.9);margin:8px 0 0;font-size:14px;">New Contact Inquiry</p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <h2 style="color:#2D5A3D;margin:0 0 8px;font-size:20px;">New Message Received</h2>
+              <p style="color:#555;margin:0 0 24px;font-size:15px;line-height:1.5;">
+                Someone reached out through the contact form.
+              </p>
+              <!-- Sender details -->
+              <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8f4ef;border-radius:8px;margin-bottom:24px;">
+                <tr>
+                  <td style="padding:20px;">
+                    <p style="margin:0 0 8px;color:#666;font-size:14px;">
+                      <span style="color:#0891b2;font-weight:600;">From:</span> ${name}
+                    </p>
+                    <p style="margin:0;color:#666;font-size:14px;">
+                      <span style="color:#0891b2;font-weight:600;">Email:</span> ${email}
+                    </p>
+                  </td>
+                </tr>
+              </table>
+              <!-- Message -->
+              <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8f4ef;border-radius:8px;">
+                <tr>
+                  <td style="padding:20px;">
+                    <p style="margin:0 0 8px;color:#0891b2;font-size:14px;font-weight:600;">Message:</p>
+                    <p style="margin:0;color:#333;font-size:15px;line-height:1.6;">${escapedMessage}</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background-color:#f8f4ef;padding:24px 32px;text-align:center;border-top:1px solid #eee;">
+              <p style="color:#999;font-size:12px;margin:0;">
+                This email was sent from the EventTara contact form. Reply directly to respond to the sender.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- Add `/contact` page with name/email/message form (client component) using existing Input and Button components
- Create `POST /api/contact` route that validates fields and sends email to `info@eventtara.com` via Resend with Reply-To set to sender's email
- Add "Have Questions?" CTA section to homepage (after organizer CTA)
- Add "Contact Us" link to footer
- Extend `sendEmail()` to support optional `replyTo` field

## Test plan
- [ ] Visit `/contact`, fill form, submit — check email arrives at info@eventtara.com
- [ ] Verify Reply-To header is set to sender's email
- [ ] Visit homepage, scroll to bottom — "Have Questions?" CTA section visible above footer
- [ ] Check footer has "Contact Us" link in "For Organizers" column
- [ ] Test mobile responsiveness on contact page and homepage CTA
- [ ] Submit form with missing fields — verify validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)