### PR TITLE
fix: add close button to booking auth modal

### DIFF
--- a/src/components/booking/AuthBookingModal.tsx
+++ b/src/components/booking/AuthBookingModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import confetti from "canvas-confetti";
+import { useRouter } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
 
 import { Button } from "@/components/ui";
@@ -18,10 +19,10 @@ interface AuthBookingModalProps {
 
 export default function AuthBookingModal({
   eventName,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   eventId,
   onAuthenticated,
 }: AuthBookingModalProps) {
+  const router = useRouter();
   const [state, setState] = useState<ModalState>("email");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState<string[]>(Array.from<string>({ length: CODE_LENGTH }).fill(""));
@@ -254,6 +255,25 @@ export default function AuthBookingModal({
           e.stopPropagation();
         }}
       >
+        {state !== "success" && (
+          <button
+            type="button"
+            onClick={() => router.push(`/events/${eventId}`)}
+            className="absolute top-4 right-4 p-1 rounded-lg text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            aria-label="Close"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+
         {state === "email" && (
           <form onSubmit={handleEmailSubmit} className="space-y-5">
             <div className="text-center">


### PR DESCRIPTION
## Summary
- Adds an X close button to the top-right corner of the booking auth modal (email and OTP screens)
- Clicking the close button redirects the user back to the event page (`/events/{id}`)
- Hidden during the success state so it doesn't interfere with the confetti animation

## Test plan
- [ ] Navigate to an event as an unauthenticated user and click "Book Now"
- [ ] Verify the X button appears on the email input screen
- [ ] Click the X button and confirm it redirects to the event detail page
- [ ] Re-enter booking, submit an email, verify the X button appears on the OTP code screen
- [ ] Click the X button from the OTP screen and confirm redirect
- [ ] Complete the full OTP flow and verify the X button is not shown on the success screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)