### PR TITLE
fix: free event bookings show correct status and companion QR codes

### DIFF
--- a/src/components/dashboard/ParticipantsTable.tsx
+++ b/src/components/dashboard/ParticipantsTable.tsx
@@ -152,7 +152,13 @@ export default function ParticipantsTable({
                     {booking.users?.email || "—"}
                   </td>
                   <td className="px-6 py-4">
-                    <PaymentStatusBadge status={booking.payment_status} />
+                    {booking.payment_method ? (
+                      <PaymentStatusBadge status={booking.payment_status} />
+                    ) : (
+                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium capitalize bg-forest-100 text-forest-700 dark:bg-forest-900/50 dark:text-forest-300">
+                        confirmed
+                      </span>
+                    )}
                   </td>
                   <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                     {booking.payment_method?.toUpperCase() || "Free"}

--- a/src/components/participant/UpcomingBookings.tsx
+++ b/src/components/participant/UpcomingBookings.tsx
@@ -104,7 +104,9 @@ export default function UpcomingBookings({ bookings }: { bookings: Booking[] }) 
                 <UIBadge variant={b.eventType as any}>
                   {typeLabels[b.eventType] || b.eventType}
                 </UIBadge>
-                {b.paymentStatus && <PaymentStatusBadge status={b.paymentStatus as any} />}
+                {b.paymentStatus && b.paymentMethod && (
+                  <PaymentStatusBadge status={b.paymentStatus as any} />
+                )}
               </div>
               <Link href={`/events/${b.eventId}`}>
                 <h3 className="font-heading font-bold text-lg hover:text-lime-600 dark:hover:text-lime-400">
@@ -187,6 +189,10 @@ export default function UpcomingBookings({ bookings }: { bookings: Booking[] }) 
                               Show at check-in
                             </p>
                           </>
+                        ) : b.eventPrice === 0 ? (
+                          <p className="text-xs text-lime-600 dark:text-lime-400 text-center">
+                            Confirmed
+                          </p>
                         ) : (
                           <p className="text-xs text-gray-400 text-center">
                             QR code pending verification


### PR DESCRIPTION
## Summary
- Generate companion QR codes inline during insert (pre-generate UUIDs) instead of a separate update that was silently failing
- Show "confirmed" instead of "paid" for free events on organizer dashboard
- Hide misleading "paid" badge for free events on participant view
- Show "Confirmed" instead of "QR code pending verification" for free event companions

## Test plan
- [ ] Book a free event with companions — verify QR codes appear immediately
- [ ] Check organizer dashboard — free event bookers should show "confirmed" not "paid"
- [ ] Check participant profile — free event booking should not show "paid" badge
- [ ] Re-seed and verify companion QR codes are generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)