### PR TITLE
feat: add custom username selection at signup and user search in explore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Code Rules
+
+- **No `as` type assertions.** Use explicit type annotations (e.g., `const data: MyType = ...`) instead of `as` casts. This applies to all new and modified code.
+
 ## Branch Workflow
 
 Before making any code changes, check the current branch. If on `main`, create a new descriptive branch based on the task:

--- a/src/app/(frontend)/api/users/check-username/route.ts
+++ b/src/app/(frontend)/api/users/check-username/route.ts
@@ -1,0 +1,35 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+
+const USERNAME_REGEX = /^[a-z0-9._-]{3,30}$/;
+
+export async function GET(request: NextRequest) {
+  const username = request.nextUrl.searchParams.get("username")?.toLowerCase().trim();
+
+  if (!username) {
+    return NextResponse.json({ available: false, error: "Username is required" }, { status: 400 });
+  }
+
+  if (!USERNAME_REGEX.test(username)) {
+    return NextResponse.json(
+      {
+        available: false,
+        error:
+          "Username must be 3-30 characters, lowercase letters, numbers, dots, underscores, or hyphens",
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+
+  const { data } = await supabase
+    .from("users")
+    .select("id")
+    .ilike("username", username)
+    .limit(1)
+    .single();
+
+  return NextResponse.json({ available: !data });
+}

--- a/src/components/events/EventsPageClient.tsx
+++ b/src/components/events/EventsPageClient.tsx
@@ -3,7 +3,10 @@
 import { useState } from "react";
 
 import EventFilters from "@/components/events/EventFilters";
-import EventsListClient, { type EventData } from "@/components/events/EventsListClient";
+import EventsListClient, {
+  type EventData,
+  type UserResult,
+} from "@/components/events/EventsListClient";
 
 interface FilterOption {
   id: string;
@@ -15,6 +18,7 @@ interface EventsPageClientProps {
   totalCount: number;
   organizers: FilterOption[];
   guides: FilterOption[];
+  initialUsers?: UserResult[];
 }
 
 export default function EventsPageClient({
@@ -22,6 +26,7 @@ export default function EventsPageClient({
   totalCount,
   organizers,
   guides,
+  initialUsers = [],
 }: EventsPageClientProps) {
   const [isFiltering, setIsFiltering] = useState(false);
 
@@ -40,6 +45,7 @@ export default function EventsPageClient({
         initialEvents={initialEvents}
         totalCount={totalCount}
         isFiltering={isFiltering}
+        initialUsers={initialUsers}
       />
     </>
   );


### PR DESCRIPTION
Allow users to pick their own @handle during signup with real-time availability checking. The event search now also surfaces matching users by username or name above event results.