### PR TITLE
fix: improve LCP performance with SSR nav, streaming, and CMS caching

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -6,26 +6,22 @@ import GoogleAnalytics from "@/components/analytics/GoogleAnalytics";
 import ClientShell from "@/components/layout/ClientShell";
 import Footer from "@/components/layout/Footer";
 import ThemeProvider from "@/components/layout/ThemeProvider";
-import { getPayloadClient } from "@/lib/payload/client";
+import { getCachedSiteSettings } from "@/lib/payload/cached";
 
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",
+  display: "swap",
 });
 
 const plusJakarta = Plus_Jakarta_Sans({
   subsets: ["latin"],
   variable: "--font-plus-jakarta",
+  display: "swap",
 });
 
 export async function generateMetadata(): Promise<Metadata> {
-  let settings;
-  try {
-    const payload = await getPayloadClient();
-    settings = await payload.findGlobal({ slug: "site-settings" });
-  } catch {
-    settings = null;
-  }
+  const settings = await getCachedSiteSettings();
 
   const siteName = settings?.siteName || "EventTara";
   const tagline = settings?.tagline || "Tara na! Book Your Next Adventure";

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,14 +1,12 @@
 import Image from "next/image";
 import Link from "next/link";
+import { Suspense } from "react";
 
-import EventCard from "@/components/events/EventCard";
-import EventCarousel from "@/components/events/EventCarousel";
 import BetaNoticeModal from "@/components/landing/BetaNoticeModal";
-import HeroCarousel from "@/components/landing/HeroCarousel";
-import HostEventLink from "@/components/landing/HostEventLink";
-import { Avatar } from "@/components/ui";
-import { getPayloadClient } from "@/lib/payload/client";
-import { createClient } from "@/lib/supabase/server";
+import HeroSection from "@/components/landing/HeroSection";
+import OrganizersSection from "@/components/landing/OrganizersSection";
+import TestimonialsSection from "@/components/landing/TestimonialsSection";
+import UpcomingEventsSection from "@/components/landing/UpcomingEventsSection";
 
 export const metadata = {
   title: "EventTara — Outdoor Adventure Events in Panay Island",
@@ -70,191 +68,101 @@ const steps = [
   },
 ];
 
-export default async function Home() {
-  const supabase = await createClient();
-  const now = new Date().toISOString();
+function UpcomingEventsSkeleton() {
+  return (
+    <section className="py-20 bg-white dark:bg-slate-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between mb-10">
+          <div className="h-9 w-56 bg-gray-200 dark:bg-slate-700 rounded-lg animate-pulse" />
+          <div className="h-5 w-16 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+        </div>
+        <div className="flex gap-4 overflow-hidden">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="min-w-[320px] h-[340px] bg-gray-100 dark:bg-slate-700 rounded-2xl animate-pulse flex-shrink-0"
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
 
-  const [
-    { count: totalUpcoming },
-    { data: upcomingEvents },
-    { data: organizers },
-    { data: testimonials },
-  ] = await Promise.all([
-    supabase
-      .from("events")
-      .select("*", { count: "exact", head: true })
-      .eq("status", "published")
-      .gte("date", now),
-    supabase
-      .from("events")
-      .select("*, bookings(count), organizer_profiles!inner(org_name)")
-      .eq("status", "published")
-      .gte("date", now)
-      .order("date", { ascending: true })
-      .limit(5),
-    supabase
-      .from("organizer_profiles")
-      .select("id, org_name, logo_url, events!inner(id)")
-      .eq("events.status", "published")
-      .limit(12),
-    supabase
-      .from("app_testimonials")
-      .select("id, name, role, text, avatar_url")
-      .eq("is_active", true)
-      .order("display_order", { ascending: true })
-      .limit(6),
-  ]);
+function OrganizersSkeleton() {
+  return (
+    <section className="py-16 bg-white dark:bg-slate-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="h-4 w-40 bg-gray-200 dark:bg-slate-700 rounded animate-pulse mx-auto mb-8" />
+        <div className="flex flex-wrap justify-center gap-6">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="flex flex-col items-center gap-2">
+              <div className="w-12 h-12 rounded-full bg-gray-200 dark:bg-slate-700 animate-pulse" />
+              <div className="h-3 w-14 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
 
-  const remainingCount = (totalUpcoming || 0) - (upcomingEvents?.length || 0);
+function TestimonialsSkeleton() {
+  return (
+    <section className="py-20 bg-gray-50 dark:bg-slate-900">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="h-9 w-64 bg-gray-200 dark:bg-slate-700 rounded-lg animate-pulse mx-auto mb-4" />
+        <div className="h-5 w-80 bg-gray-200 dark:bg-slate-700 rounded animate-pulse mx-auto mb-12" />
+        <div className="flex gap-4 overflow-hidden">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="min-w-[300px] h-[180px] bg-white dark:bg-slate-800 rounded-2xl animate-pulse flex-shrink-0"
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
 
-  // Dedupe (inner join can return multiples) and sort by event count
-  const uniqueOrganizers = organizers
-    ? Object.values(
-        organizers.reduce<
-          Record<
-            string,
-            { id: string; org_name: string; logo_url: string | null; event_count: number }
-          >
-        >((acc, org: any) => {
-          if (!acc[org.id]) {
-            acc[org.id] = {
-              id: org.id,
-              org_name: org.org_name,
-              logo_url: org.logo_url,
-              event_count: 0,
-            };
-          }
-          acc[org.id].event_count += Array.isArray(org.events) ? org.events.length : 1;
-          return acc;
-        }, {}),
-      ).sort((a, b) => b.event_count - a.event_count)
-    : [];
-
-  // Fetch hero carousel images from Payload CMS
-  let heroSlides: { image: { url: string; alt: string } }[] = [];
-  try {
-    const payload = await getPayloadClient();
-    const heroData = await payload.findGlobal({ slug: "hero-carousel" });
-    if (heroData?.slides) {
-      heroSlides = heroData.slides
-        .filter((slide: any) => slide.image && typeof slide.image === "object")
-        .map((slide: any) => ({
-          image: {
-            url: slide.image.url,
-            alt: slide.image.alt || "Adventure",
-          },
-        }));
-    }
-  } catch {
-    // Fallback: no carousel images
-  }
-
+export default function Home() {
   return (
     <main>
       <BetaNoticeModal />
 
-      {/* Hero Section */}
-      <section className="relative py-24 sm:py-32 overflow-hidden min-h-[500px] flex items-center">
-        {heroSlides.length > 0 ? (
-          <HeroCarousel slides={heroSlides} />
-        ) : (
-          <>
-            {/* Fallback: original flat background */}
+      {/* Hero Section — streams independently (Payload CMS fetch) */}
+      <Suspense
+        fallback={
+          <section className="relative py-24 sm:py-32 overflow-hidden min-h-[500px] flex items-center">
             <div className="absolute inset-0 bg-gray-50 dark:bg-slate-900" />
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-lime-500/10 rounded-full blur-3xl" />
-          </>
-        )}
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10 w-full">
-          <div className="inline-block mb-6 px-4 py-1.5 rounded-full bg-lime-500/10 border border-lime-500/30">
-            <span className="text-lime-600 dark:text-lime-400 text-sm font-semibold tracking-wide uppercase">
-              Beta — Now Live
-            </span>
-          </div>
-          <h1
-            className={`text-5xl sm:text-7xl font-heading font-bold mb-4 ${heroSlides.length > 0 ? "text-white" : "text-gray-900 dark:text-white"}`}
-          >
-            Tara na!
-          </h1>
-          <p
-            className={`text-xl sm:text-2xl mb-10 max-w-2xl mx-auto ${heroSlides.length > 0 ? "text-gray-200" : "text-gray-600 dark:text-gray-400"}`}
-          >
-            Book Your Next Adventure. Discover hiking, biking, running events and more across the
-            Philippines.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link
-              href="/events"
-              className="inline-flex items-center justify-center font-semibold rounded-xl text-lg py-4 px-8 bg-lime-500 hover:bg-lime-400 text-slate-900 transition-colors"
-            >
-              Explore Events
-            </Link>
-            <HostEventLink />
-          </div>
-        </div>
-      </section>
-
-      {/* Upcoming Events */}
-      {upcomingEvents && upcomingEvents.length > 0 && (
-        <section className="py-20 bg-white dark:bg-slate-800">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex items-center justify-between mb-10">
-              <h2 className="text-3xl sm:text-4xl font-heading font-bold text-gray-900 dark:text-white">
-                Upcoming Events
-              </h2>
-              <Link
-                href="/events?when=upcoming"
-                className="text-lime-600 dark:text-lime-400 font-semibold hover:underline"
-              >
-                View all
-              </Link>
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10 w-full">
+              <div className="inline-block mb-6 px-4 py-1.5 rounded-full bg-lime-500/10 border border-lime-500/30">
+                <span className="text-lime-600 dark:text-lime-400 text-sm font-semibold tracking-wide uppercase">
+                  Beta — Now Live
+                </span>
+              </div>
+              <h1 className="text-5xl sm:text-7xl font-heading font-bold mb-4 text-gray-900 dark:text-white">
+                Tara na!
+              </h1>
+              <p className="text-xl sm:text-2xl mb-10 max-w-2xl mx-auto text-gray-600 dark:text-gray-400">
+                Book Your Next Adventure. Discover hiking, biking, running events and more across
+                the Philippines.
+              </p>
             </div>
-            <EventCarousel>
-              {upcomingEvents.map((event: any) => (
-                <div
-                  key={event.id}
-                  className="md:min-w-[320px] md:max-w-[350px] md:flex-shrink-0"
-                  style={{ scrollSnapAlign: "start" }}
-                >
-                  <EventCard
-                    id={event.id}
-                    title={event.title}
-                    type={event.type}
-                    date={event.date}
-                    location={event.location}
-                    price={Number(event.price)}
-                    cover_image_url={event.cover_image_url}
-                    max_participants={event.max_participants}
-                    booking_count={event.bookings?.[0]?.count || 0}
-                    organizer_name={event.organizer_profiles?.org_name}
-                    organizer_id={event.organizer_id}
-                    status="upcoming"
-                  />
-                </div>
-              ))}
-              {remainingCount > 0 && (
-                <div
-                  className="md:min-w-[280px] md:flex-shrink-0"
-                  style={{ scrollSnapAlign: "start" }}
-                >
-                  <Link
-                    href="/events"
-                    className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-300 dark:border-slate-600 hover:border-lime-500 dark:hover:border-lime-500 transition-colors h-full min-h-[280px]"
-                  >
-                    <span className="text-3xl font-heading font-bold text-lime-600 dark:text-lime-400">
-                      +{remainingCount}
-                    </span>
-                    <span className="text-gray-500 dark:text-gray-400 mt-1 font-medium">
-                      more events
-                    </span>
-                  </Link>
-                </div>
-              )}
-            </EventCarousel>
-          </div>
-        </section>
-      )}
+          </section>
+        }
+      >
+        <HeroSection />
+      </Suspense>
 
-      {/* How It Works */}
+      {/* Upcoming Events — streams as Supabase data arrives */}
+      <Suspense fallback={<UpcomingEventsSkeleton />}>
+        <UpcomingEventsSection />
+      </Suspense>
+
+      {/* How It Works — static, renders immediately */}
       <section className="py-20 bg-white dark:bg-slate-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl sm:text-4xl font-heading font-bold text-center text-gray-900 dark:text-white mb-12">
@@ -274,7 +182,7 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* Event Categories */}
+      {/* Event Categories — static images, renders immediately */}
       <section className="py-20 bg-gray-50 dark:bg-slate-900">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl sm:text-4xl font-heading font-bold text-center text-gray-900 dark:text-white mb-12">
@@ -306,85 +214,17 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* Trusted Organizers */}
-      {uniqueOrganizers.length > 0 && (
-        <section className="py-16 bg-white dark:bg-slate-800">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <p className="text-center text-sm font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-8">
-              Trusted by Organizers
-            </p>
-            <div className="flex flex-wrap justify-center gap-6">
-              {uniqueOrganizers.map((org) => (
-                <Link
-                  key={org.id}
-                  href={`/organizers/${org.id}`}
-                  className="flex flex-col items-center gap-2 group"
-                >
-                  <Avatar
-                    src={org.logo_url}
-                    alt={org.org_name}
-                    size="lg"
-                    className="ring-2 ring-transparent group-hover:ring-lime-500 transition-all group-hover:scale-110"
-                  />
-                  <span className="text-xs text-gray-500 dark:text-gray-400 group-hover:text-lime-600 dark:group-hover:text-lime-400 transition-colors font-medium max-w-[80px] text-center truncate">
-                    {org.org_name}
-                  </span>
-                </Link>
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
+      {/* Trusted Organizers — streams as Supabase data arrives */}
+      <Suspense fallback={<OrganizersSkeleton />}>
+        <OrganizersSection />
+      </Suspense>
 
-      {/* Participant Testimonials */}
-      {testimonials && testimonials.length > 0 && (
-        <section className="py-20 bg-gray-50 dark:bg-slate-900">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 className="text-3xl sm:text-4xl font-heading font-bold text-center text-gray-900 dark:text-white mb-4">
-              What Adventurers Say
-            </h2>
-            <p className="text-center text-gray-500 dark:text-gray-400 mb-12 max-w-2xl mx-auto">
-              Hear from the community that makes EventTara special.
-            </p>
-            <EventCarousel infinite speed={30}>
-              {testimonials.map((t: any) => (
-                <div key={t.id} className="min-w-[300px] max-w-[380px] flex-shrink-0">
-                  <div className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-sm dark:shadow-gray-950/20 h-full">
-                    <div className="flex items-center gap-3 mb-4">
-                      <div className="w-10 h-10 rounded-full bg-lime-100 dark:bg-lime-900/30 overflow-hidden flex-shrink-0 flex items-center justify-center">
-                        {t.avatar_url ? (
-                          <Image
-                            src={t.avatar_url}
-                            alt={t.name}
-                            width={40}
-                            height={40}
-                            className="object-cover w-full h-full"
-                          />
-                        ) : (
-                          <span className="text-lime-600 dark:text-lime-400 font-bold text-sm">
-                            {t.name.charAt(0).toUpperCase()}
-                          </span>
-                        )}
-                      </div>
-                      <div>
-                        <p className="font-semibold text-sm text-gray-900 dark:text-white">
-                          {t.name}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">{t.role}</p>
-                      </div>
-                    </div>
-                    <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
-                      &ldquo;{t.text}&rdquo;
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </EventCarousel>
-          </div>
-        </section>
-      )}
+      {/* Participant Testimonials — streams as Supabase data arrives */}
+      <Suspense fallback={<TestimonialsSkeleton />}>
+        <TestimonialsSection />
+      </Suspense>
 
-      {/* Organizer CTA */}
+      {/* Organizer CTA — static */}
       <section className="py-20 bg-lime-400 dark:bg-lime-500">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl sm:text-4xl font-heading font-bold text-slate-900 mb-4">
@@ -403,7 +243,7 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* Contact CTA */}
+      {/* Contact CTA — static */}
       <section className="py-20 bg-white dark:bg-slate-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl sm:text-4xl font-heading font-bold text-gray-900 dark:text-white mb-4">

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import HeroCarousel from "@/components/landing/HeroCarousel";
+import HostEventLink from "@/components/landing/HostEventLink";
+import { getCachedHeroCarousel } from "@/lib/payload/cached";
+
+export default async function HeroSection() {
+  const heroData = await getCachedHeroCarousel();
+  const heroSlides: { image: { url: string; alt: string } }[] = heroData?.slides
+    ? heroData.slides
+        .filter((slide: any) => slide.image && typeof slide.image === "object")
+        .map((slide: any) => ({
+          image: {
+            url: slide.image.url,
+            alt: slide.image.alt || "Adventure",
+          },
+        }))
+    : [];
+
+  return (
+    <section className="relative py-24 sm:py-32 overflow-hidden min-h-[500px] flex items-center">
+      {heroSlides.length > 0 ? (
+        <HeroCarousel slides={heroSlides} />
+      ) : (
+        <>
+          <div className="absolute inset-0 bg-gray-50 dark:bg-slate-900" />
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-lime-500/10 rounded-full blur-3xl" />
+        </>
+      )}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10 w-full">
+        <div className="inline-block mb-6 px-4 py-1.5 rounded-full bg-lime-500/10 border border-lime-500/30">
+          <span className="text-lime-600 dark:text-lime-400 text-sm font-semibold tracking-wide uppercase">
+            Beta — Now Live
+          </span>
+        </div>
+        <h1
+          className={`text-5xl sm:text-7xl font-heading font-bold mb-4 ${heroSlides.length > 0 ? "text-white" : "text-gray-900 dark:text-white"}`}
+        >
+          Tara na!
+        </h1>
+        <p
+          className={`text-xl sm:text-2xl mb-10 max-w-2xl mx-auto ${heroSlides.length > 0 ? "text-gray-200" : "text-gray-600 dark:text-gray-400"}`}
+        >
+          Book Your Next Adventure. Discover hiking, biking, running events and more across the
+          Philippines.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <Link
+            href="/events"
+            className="inline-flex items-center justify-center font-semibold rounded-xl text-lg py-4 px-8 bg-lime-500 hover:bg-lime-400 text-slate-900 transition-colors"
+          >
+            Explore Events
+          </Link>
+          <HostEventLink />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/OrganizersSection.tsx
+++ b/src/components/landing/OrganizersSection.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+
+import { Avatar } from "@/components/ui";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function OrganizersSection() {
+  const supabase = await createClient();
+
+  const { data: organizers } = await supabase
+    .from("organizer_profiles")
+    .select("id, org_name, logo_url, events!inner(id)")
+    .eq("events.status", "published")
+    .limit(12);
+
+  // Dedupe (inner join can return multiples) and sort by event count
+  const uniqueOrganizers = organizers
+    ? Object.values(
+        organizers.reduce<
+          Record<
+            string,
+            { id: string; org_name: string; logo_url: string | null; event_count: number }
+          >
+        >((acc, org: any) => {
+          if (!acc[org.id]) {
+            acc[org.id] = {
+              id: org.id,
+              org_name: org.org_name,
+              logo_url: org.logo_url,
+              event_count: 0,
+            };
+          }
+          acc[org.id].event_count += Array.isArray(org.events) ? org.events.length : 1;
+          return acc;
+        }, {}),
+      ).sort((a, b) => b.event_count - a.event_count)
+    : [];
+
+  if (uniqueOrganizers.length === 0) return null;
+
+  return (
+    <section className="py-16 bg-white dark:bg-slate-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <p className="text-center text-sm font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-8">
+          Trusted by Organizers
+        </p>
+        <div className="flex flex-wrap justify-center gap-6">
+          {uniqueOrganizers.map((org) => (
+            <Link
+              key={org.id}
+              href={`/organizers/${org.id}`}
+              className="flex flex-col items-center gap-2 group"
+            >
+              <Avatar
+                src={org.logo_url}
+                alt={org.org_name}
+                size="lg"
+                className="ring-2 ring-transparent group-hover:ring-lime-500 transition-all group-hover:scale-110"
+              />
+              <span className="text-xs text-gray-500 dark:text-gray-400 group-hover:text-lime-600 dark:group-hover:text-lime-400 transition-colors font-medium max-w-[80px] text-center truncate">
+                {org.org_name}
+              </span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/TestimonialsSection.tsx
+++ b/src/components/landing/TestimonialsSection.tsx
@@ -1,0 +1,62 @@
+import Image from "next/image";
+
+import EventCarousel from "@/components/events/EventCarousel";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function TestimonialsSection() {
+  const supabase = await createClient();
+
+  const { data: testimonials } = await supabase
+    .from("app_testimonials")
+    .select("id, name, role, text, avatar_url")
+    .eq("is_active", true)
+    .order("display_order", { ascending: true })
+    .limit(6);
+
+  if (!testimonials || testimonials.length === 0) return null;
+
+  return (
+    <section className="py-20 bg-gray-50 dark:bg-slate-900">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl sm:text-4xl font-heading font-bold text-center text-gray-900 dark:text-white mb-4">
+          What Adventurers Say
+        </h2>
+        <p className="text-center text-gray-500 dark:text-gray-400 mb-12 max-w-2xl mx-auto">
+          Hear from the community that makes EventTara special.
+        </p>
+        <EventCarousel infinite speed={30}>
+          {testimonials.map((t: any) => (
+            <div key={t.id} className="min-w-[300px] max-w-[380px] flex-shrink-0">
+              <div className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-sm dark:shadow-gray-950/20 h-full">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-10 h-10 rounded-full bg-lime-100 dark:bg-lime-900/30 overflow-hidden flex-shrink-0 flex items-center justify-center">
+                    {t.avatar_url ? (
+                      <Image
+                        src={t.avatar_url}
+                        alt={t.name}
+                        width={40}
+                        height={40}
+                        className="object-cover w-full h-full"
+                      />
+                    ) : (
+                      <span className="text-lime-600 dark:text-lime-400 font-bold text-sm">
+                        {t.name.charAt(0).toUpperCase()}
+                      </span>
+                    )}
+                  </div>
+                  <div>
+                    <p className="font-semibold text-sm text-gray-900 dark:text-white">{t.name}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">{t.role}</p>
+                  </div>
+                </div>
+                <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
+                  &ldquo;{t.text}&rdquo;
+                </p>
+              </div>
+            </div>
+          ))}
+        </EventCarousel>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/UpcomingEventsSection.tsx
+++ b/src/components/landing/UpcomingEventsSection.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+
+import EventCard from "@/components/events/EventCard";
+import EventCarousel from "@/components/events/EventCarousel";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function UpcomingEventsSection() {
+  const supabase = await createClient();
+  const now = new Date().toISOString();
+
+  const [{ count: totalUpcoming }, { data: upcomingEvents }] = await Promise.all([
+    supabase
+      .from("events")
+      .select("*", { count: "exact", head: true })
+      .eq("status", "published")
+      .gte("date", now),
+    supabase
+      .from("events")
+      .select("*, bookings(count), organizer_profiles!inner(org_name)")
+      .eq("status", "published")
+      .gte("date", now)
+      .order("date", { ascending: true })
+      .limit(5),
+  ]);
+
+  if (!upcomingEvents || upcomingEvents.length === 0) return null;
+
+  const remainingCount = (totalUpcoming || 0) - upcomingEvents.length;
+
+  return (
+    <section className="py-20 bg-white dark:bg-slate-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between mb-10">
+          <h2 className="text-3xl sm:text-4xl font-heading font-bold text-gray-900 dark:text-white">
+            Upcoming Events
+          </h2>
+          <Link
+            href="/events?when=upcoming"
+            className="text-lime-600 dark:text-lime-400 font-semibold hover:underline"
+          >
+            View all
+          </Link>
+        </div>
+        <EventCarousel>
+          {upcomingEvents.map((event: any) => (
+            <div
+              key={event.id}
+              className="md:min-w-[320px] md:max-w-[350px] md:flex-shrink-0"
+              style={{ scrollSnapAlign: "start" }}
+            >
+              <EventCard
+                id={event.id}
+                title={event.title}
+                type={event.type}
+                date={event.date}
+                location={event.location}
+                price={Number(event.price)}
+                cover_image_url={event.cover_image_url}
+                max_participants={event.max_participants}
+                booking_count={event.bookings?.[0]?.count || 0}
+                organizer_name={event.organizer_profiles?.org_name}
+                organizer_id={event.organizer_id}
+                status="upcoming"
+              />
+            </div>
+          ))}
+          {remainingCount > 0 && (
+            <div className="md:min-w-[280px] md:flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
+              <Link
+                href="/events"
+                className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-300 dark:border-slate-600 hover:border-lime-500 dark:hover:border-lime-500 transition-colors h-full min-h-[280px]"
+              >
+                <span className="text-3xl font-heading font-bold text-lime-600 dark:text-lime-400">
+                  +{remainingCount}
+                </span>
+                <span className="text-gray-500 dark:text-gray-400 mt-1 font-medium">
+                  more events
+                </span>
+              </Link>
+            </div>
+          )}
+        </EventCarousel>
+      </div>
+    </section>
+  );
+}

--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -9,7 +9,6 @@ import MobileDrawer from "@/components/layout/MobileDrawer";
 import { createClient } from "@/lib/supabase/client";
 
 const Navbar = dynamic(() => import("@/components/layout/Navbar"), {
-  ssr: false,
   loading: () => (
     <nav className="bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -21,7 +20,6 @@ const Navbar = dynamic(() => import("@/components/layout/Navbar"), {
   ),
 });
 const MobileNav = dynamic(() => import("@/components/layout/MobileNav"), {
-  ssr: false,
   loading: () => (
     <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 h-16 safe-area-bottom" />
   ),

--- a/src/lib/payload/cached.ts
+++ b/src/lib/payload/cached.ts
@@ -1,0 +1,37 @@
+import { unstable_cache } from "next/cache";
+
+import { getPayloadClient } from "./client";
+
+/**
+ * Cached Payload CMS site-settings fetch.
+ * Revalidates every 60 seconds to avoid blocking TTFB on every page load.
+ */
+export const getCachedSiteSettings = unstable_cache(
+  async () => {
+    try {
+      const payload = await getPayloadClient();
+      return await payload.findGlobal({ slug: "site-settings" });
+    } catch {
+      return null;
+    }
+  },
+  ["site-settings"],
+  { revalidate: 60 },
+);
+
+/**
+ * Cached Payload CMS hero-carousel fetch.
+ * Revalidates every 60 seconds.
+ */
+export const getCachedHeroCarousel = unstable_cache(
+  async () => {
+    try {
+      const payload = await getPayloadClient();
+      return await payload.findGlobal({ slug: "hero-carousel" });
+    } catch {
+      return null;
+    }
+  },
+  ["hero-carousel"],
+  { revalidate: 60 },
+);


### PR DESCRIPTION
## Summary

- **Enable SSR for Navbar/MobileNav** — removed `ssr: false` from dynamic imports so navigation HTML is included in the initial server response instead of waiting for JS hydration
- **Stream homepage with Suspense** — split monolithic homepage into async server components (`HeroSection`, `UpcomingEventsSection`, `OrganizersSection`, `TestimonialsSection`) each wrapped in `<Suspense>` with skeleton fallbacks. Static sections (How It Works, Categories, CTAs) render immediately without blocking on data
- **Cache Payload CMS calls** — `generateMetadata` site-settings and hero-carousel now use `unstable_cache` with 60s revalidation, eliminating blocking CMS queries on every page load
- **Explicit font `display: swap`** — both Inter and Plus Jakarta Sans now explicitly set `display: "swap"` to prevent font-blocking render delays

## Test plan

- [ ] Verify homepage loads with streaming (hero appears first, then events/organizers/testimonials stream in)
- [ ] Verify navigation renders in initial HTML (check page source — full nav markup should be present)
- [ ] Verify skeleton loading states appear briefly while data streams
- [ ] Verify all sections render correctly once data loads (events, organizers, testimonials)
- [ ] Run PageSpeed Insights and compare LCP/FCP scores against baseline
- [ ] Test on mobile viewport — hero text should appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)