### PR TITLE
fix: improve Speed Index with lazy drawer, server navLayout, preconnects

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -78,17 +78,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const settings = await getCachedSiteSettings();
+  const navLayout = (settings?.navLayout as string) || "strip";
+
   return (
     <html
       lang="en"
       className={`${inter.variable} ${plusJakarta.variable}`}
       suppressHydrationWarning
     >
+      <head>
+        {process.env.NEXT_PUBLIC_SUPABASE_URL && (
+          <link rel="preconnect" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
+        )}
+        <link rel="preconnect" href="https://images.unsplash.com" />
+      </head>
       <GoogleAnalytics />
       <body className="font-sans min-h-screen flex flex-col">
         <ThemeProvider>
-          <ClientShell>{children}</ClientShell>
+          <ClientShell initialNavLayout={navLayout}>{children}</ClientShell>
           <Footer />
         </ThemeProvider>
       </body>

--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -5,8 +5,9 @@ import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import MobileDrawer from "@/components/layout/MobileDrawer";
 import { createClient } from "@/lib/supabase/client";
+
+const MobileDrawer = dynamic(() => import("@/components/layout/MobileDrawer"));
 
 const Navbar = dynamic(() => import("@/components/layout/Navbar"), {
   loading: () => (
@@ -58,14 +59,19 @@ const activities = [
   },
 ];
 
-export default function ClientShell({ children }: { children: React.ReactNode }) {
+interface ClientShellProps {
+  children: React.ReactNode;
+  initialNavLayout?: string;
+}
+
+export default function ClientShell({ children, initialNavLayout = "strip" }: ClientShellProps) {
   const pathname = usePathname();
   const supabase = createClient();
   const [user, setUser] = useState<User | null>(null);
   const [role, setRole] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [navLayout, setNavLayout] = useState<string>("strip");
+  const [navLayout] = useState<string>(initialNavLayout);
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
 
@@ -109,22 +115,6 @@ export default function ClientShell({ children }: { children: React.ReactNode })
       subscription.unsubscribe();
     };
   }, [supabase, fetchRole]);
-
-  // Fetch nav layout from Payload site-settings
-  useEffect(() => {
-    const fetchNavLayout = async () => {
-      try {
-        const res = await fetch("/api/globals/site-settings");
-        if (res.ok) {
-          const data: { navLayout?: string } = await res.json();
-          if (data.navLayout) setNavLayout(data.navLayout);
-        }
-      } catch {
-        // Payload unavailable — keep default "strip"
-      }
-    };
-    void fetchNavLayout();
-  }, []);
 
   // Edge swipe detection (right 20px edge, swipe left to open)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Lazy-load MobileDrawer** — uses `dynamic()` so the drawer JS bundle only loads when user opens it, reducing initial JS payload
- **Remove client-side site-settings fetch** — `navLayout` is now passed from the server layout (via the already-cached Payload CMS call) instead of making a separate `/api/globals/site-settings` request on every page load
- **Add preconnect hints** — `<link rel="preconnect">` for Supabase and Unsplash domains so the browser establishes connections early before images are needed

## Test plan

- [ ] Verify navbar still renders correctly with explore dropdown layouts
- [ ] Verify mobile drawer still opens/closes properly (swipe + hamburger menu)
- [ ] Check Network tab — no more `/api/globals/site-settings` request on page load
- [ ] Verify preconnect links appear in page source `<head>`
- [ ] Run PageSpeed Insights and compare Speed Index against baseline (~80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)