### PR TITLE
fix: optimize dynamic imports for Speed Index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Code Rules
 
 - **No `as` type assertions in components.** Use explicit type annotations (e.g., `const data: MyType = ...`) instead of `as` casts. Enforced by ESLint in `src/components/`. Page/API files may still use `as` for Supabase joined-query types until the type system is improved.
+- **Dynamic imports — use `dynamic()` only when justified.** Apply `next/dynamic` for: (1) components with heavy third-party deps like maps (leaflet), date pickers (react-day-picker), confetti (canvas-confetti); (2) components behind user interaction (modals, drawers, dropdowns that may never open); (3) components requiring `ssr: false` (browser-only APIs like leaflet, canvas). Do NOT dynamically import: critical above-fold layout components (navbar, footer), lightweight components (<100 lines, no heavy deps), or components that always render on page load.
 
 ## Branch Workflow
 

--- a/src/components/booking/BookingPageClient.tsx
+++ b/src/components/booking/BookingPageClient.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState } from "react";
 
-import AuthBookingModal from "./AuthBookingModal";
 import BookingForm from "./BookingForm";
+
+const AuthBookingModal = dynamic(() => import("./AuthBookingModal"), { ssr: false });
 
 interface BookingPageClientProps {
   isAuthenticated: boolean;

--- a/src/components/dashboard/EventForm.tsx
+++ b/src/components/dashboard/EventForm.tsx
@@ -5,12 +5,13 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
 
-import { Button, Input, DateRangePicker } from "@/components/ui";
+import { Button, Input } from "@/components/ui";
 import { findProvinceFromLocation } from "@/lib/constants/philippine-provinces";
 
 import PhotoUploader from "./PhotoUploader";
 
 const MapPicker = dynamic(() => import("@/components/maps/MapPicker"), { ssr: false });
+const DateRangePicker = dynamic(() => import("@/components/ui/DateRangePicker"));
 
 interface EventFormProps {
   mode: "create" | "edit";

--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -5,26 +5,11 @@ import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import MobileNav from "@/components/layout/MobileNav";
+import Navbar from "@/components/layout/Navbar";
 import { createClient } from "@/lib/supabase/client";
 
 const MobileDrawer = dynamic(() => import("@/components/layout/MobileDrawer"));
-
-const Navbar = dynamic(() => import("@/components/layout/Navbar"), {
-  loading: () => (
-    <nav className="bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 sticky top-0 z-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
-          <span className="text-2xl font-heading font-bold text-lime-500">EventTara</span>
-        </div>
-      </div>
-    </nav>
-  ),
-});
-const MobileNav = dynamic(() => import("@/components/layout/MobileNav"), {
-  loading: () => (
-    <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 h-16 safe-area-bottom" />
-  ),
-});
 
 const activities = [
   {


### PR DESCRIPTION
## Summary

Audited all dynamic imports and fixed misuse — eager-import critical layout, lazy-load heavy deps:

- **Navbar & MobileNav → eager imports** — these are critical above-fold layout components that always render. Dynamic importing them added unnecessary chunk-loading latency, hurting Speed Index
- **MobileDrawer → keep dynamic** — conditionally rendered (only when drawer opens), user may never trigger it
- **AuthBookingModal → dynamic + ssr: false** — conditionally rendered (only for unauthenticated users), imports `canvas-confetti` which is heavy and needs browser APIs
- **DateRangePicker → dynamic** — imports `react-day-picker` + `date-fns`, only used on dashboard event forms
- **Added dynamic import rule to CLAUDE.md** — documents when to use/avoid `dynamic()` for future development

## Test plan

- [ ] Verify navbar renders immediately without flash/skeleton on page load
- [ ] Verify mobile bottom nav renders immediately
- [ ] Verify mobile drawer still opens/closes correctly
- [ ] Verify booking page auth modal works for unauthenticated users
- [ ] Verify event create/edit form date picker renders correctly
- [ ] Run PageSpeed Insights and compare Speed Index

🤖 Generated with [Claude Code](https://claude.com/claude-code)