### PR TITLE
fix: contain Leaflet map z-index within stacking context

### DIFF
--- a/src/components/maps/MapDisplay.tsx
+++ b/src/components/maps/MapDisplay.tsx
@@ -13,7 +13,7 @@ interface MapDisplayProps {
 export default function MapDisplay({ lat, lng, label }: MapDisplayProps) {
   return (
     <div
-      className="rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700"
+      className="relative z-0 rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700"
       style={{ height: 250 }}
     >
       <MapContainer

--- a/src/components/maps/MapPicker.tsx
+++ b/src/components/maps/MapPicker.tsx
@@ -64,7 +64,7 @@ export default function MapPicker({ value, onChange, center }: MapPickerProps) {
   return (
     <div className="space-y-2">
       <div
-        className="rounded-xl overflow-hidden border border-gray-300 dark:border-gray-600"
+        className="relative z-0 rounded-xl overflow-hidden border border-gray-300 dark:border-gray-600"
         style={{ height: 300 }}
       >
         <MapContainer


### PR DESCRIPTION
## Summary
- Leaflet's CSS internally uses z-index 400-800, causing the map on `/events/[id]` to render above navbars, modals, and other UI elements
- Added `relative z-0` to the map wrapper div in both `MapDisplay` and `MapPicker` to create a new stacking context
- Leaflet's high z-index values are now scoped within the wrapper and no longer escape to compete with the app's UI layers

## Test plan
- [ ] Visit `/events/[id]` with a map — verify the map no longer overlaps the navbar or mobile nav
- [ ] Open any modal/dropdown on the page — verify it renders above the map
- [x] Check the map picker on event create/edit — verify it behaves correctly and doesn't overlap form elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)