### PR TITLE
fix: improve chatbot mobile UX

### DIFF
--- a/src/components/chat/ChatBubble.tsx
+++ b/src/components/chat/ChatBubble.tsx
@@ -9,8 +9,8 @@ import ChatPanel from "./ChatPanel";
 
 export default function ChatBubble() {
   const [open, setOpen] = useState(false);
-  const keyboardHeight = useKeyboardHeight();
-  const keyboardOpen = keyboardHeight > 0;
+  const keyboard = useKeyboardHeight();
+  const keyboardOpen = keyboard.keyboardHeight > 0;
 
   const handleClose = useCallback(() => setOpen(false), []);
   const handleToggle = useCallback(() => setOpen((prev) => !prev), []);
@@ -26,7 +26,7 @@ export default function ChatBubble() {
         onClick={handleClose}
       />
 
-      <ChatPanel open={open} onClose={handleClose} keyboardHeight={keyboardHeight} />
+      <ChatPanel open={open} onClose={handleClose} keyboard={keyboard} />
 
       <button
         onClick={handleToggle}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -113,7 +113,7 @@ function getNavItems(user: User | null, role: string | null, pathname: string): 
 
 export default function MobileNav({ user, role }: MobileNavProps) {
   const pathname = usePathname();
-  const keyboardHeight = useKeyboardHeight();
+  const { keyboardHeight } = useKeyboardHeight();
   const keyboardOpen = keyboardHeight > 0;
 
   // Hide on auth pages

--- a/src/lib/hooks/useKeyboardHeight.ts
+++ b/src/lib/hooks/useKeyboardHeight.ts
@@ -2,29 +2,40 @@
 
 import { useEffect, useState } from "react";
 
+interface KeyboardState {
+  /** Keyboard height in pixels (0 when closed) */
+  keyboardHeight: number;
+  /** How far iOS has scrolled the page to show the input (visualViewport.offsetTop) */
+  viewportOffset: number;
+}
+
 /**
- * Returns the current virtual keyboard height in pixels using the Visual Viewport API.
- * Returns 0 on desktop or when the keyboard is closed.
+ * Tracks the virtual keyboard height and viewport scroll offset
+ * using the Visual Viewport API. Needed on iOS where the browser
+ * scrolls the page when focusing inputs inside fixed elements.
  */
-export function useKeyboardHeight(): number {
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
+export function useKeyboardHeight(): KeyboardState {
+  const [state, setState] = useState<KeyboardState>({ keyboardHeight: 0, viewportOffset: 0 });
 
   useEffect(() => {
     const vv = window.visualViewport;
     if (!vv) return;
 
     const update = () => {
-      // When the keyboard is open, visualViewport.height shrinks.
-      // The keyboard height is the difference between the window and viewport heights.
       const kbHeight = Math.max(0, window.innerHeight - vv.height);
-      // Only treat as keyboard if the difference is meaningful (> 100px)
-      // to avoid false positives from browser chrome changes.
-      setKeyboardHeight(kbHeight > 100 ? kbHeight : 0);
+      setState({
+        keyboardHeight: kbHeight > 100 ? kbHeight : 0,
+        viewportOffset: vv.offsetTop,
+      });
     };
 
     vv.addEventListener("resize", update);
-    return () => vv.removeEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
   }, []);
 
-  return keyboardHeight;
+  return state;
 }


### PR DESCRIPTION
## Summary
- Prevent iOS auto-zoom on chatbot input by using `text-base` (16px) instead of `text-sm` (14px)
- Add dimmed backdrop overlay when chat panel is open — tapping outside dismisses the panel

## Test plan
- [ ] Open chatbot on iOS/mobile — input should not trigger page zoom
- [ ] Background should dim when chat is open
- [ ] Tapping the dimmed backdrop should close the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)