### PR TITLE
feat: seed organizer borders and display on organizer profile page

### DIFF
--- a/src/app/(frontend)/(participant)/organizers/[id]/page.tsx
+++ b/src/app/(frontend)/(participant)/organizers/[id]/page.tsx
@@ -7,6 +7,7 @@ import OrganizerProfileHeader from "@/components/organizers/OrganizerProfileHead
 import OrganizerStats from "@/components/organizers/OrganizerStats";
 import StarRating from "@/components/reviews/StarRating";
 import { Button } from "@/components/ui";
+import type { BorderTier } from "@/lib/constants/avatar-borders";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -47,7 +48,7 @@ export default async function OrganizerProfilePage({
   // Fetch organizer profile with user info
   const { data: profile } = await supabase
     .from("organizer_profiles")
-    .select("*, users:user_id(full_name, avatar_url, created_at)")
+    .select("*, users:user_id(full_name, avatar_url, created_at, active_border_id)")
     .eq("id", id)
     .single();
 
@@ -159,6 +160,21 @@ export default async function OrganizerProfilePage({
 
   const user = profile.users as any;
 
+  // Fetch active border tier for the organizer
+  let borderTier: BorderTier | null = null;
+  let borderColor: string | null = null;
+  if (user?.active_border_id) {
+    const { data: border } = await supabase
+      .from("avatar_borders")
+      .select("tier, border_color")
+      .eq("id", user.active_border_id)
+      .single();
+    if (border) {
+      borderTier = border.tier;
+      borderColor = border.border_color;
+    }
+  }
+
   // Check if the viewer is the organizer
   const {
     data: { user: authUser },
@@ -173,6 +189,8 @@ export default async function OrganizerProfilePage({
         description={profile.description}
         createdAt={user?.created_at || profile.created_at}
         isOwnProfile={isOwnProfile}
+        borderTier={borderTier}
+        borderColor={borderColor}
       />
 
       <OrganizerStats

--- a/src/components/organizers/OrganizerProfileHeader.tsx
+++ b/src/components/organizers/OrganizerProfileHeader.tsx
@@ -3,7 +3,9 @@
 import Link from "next/link";
 import { useState } from "react";
 
-import { Avatar, Button } from "@/components/ui";
+import { Button } from "@/components/ui";
+import UserAvatar from "@/components/ui/UserAvatar";
+import type { BorderTier } from "@/lib/constants/avatar-borders";
 
 interface OrganizerProfileHeaderProps {
   orgName: string;
@@ -11,6 +13,8 @@ interface OrganizerProfileHeaderProps {
   description: string | null;
   createdAt: string;
   isOwnProfile?: boolean;
+  borderTier?: BorderTier | null;
+  borderColor?: string | null;
 }
 
 export default function OrganizerProfileHeader({
@@ -19,6 +23,8 @@ export default function OrganizerProfileHeader({
   description,
   createdAt,
   isOwnProfile,
+  borderTier,
+  borderColor,
 }: OrganizerProfileHeaderProps) {
   const [copied, setCopied] = useState(false);
 
@@ -37,7 +43,14 @@ export default function OrganizerProfileHeader({
 
   return (
     <div className="text-center space-y-4">
-      <Avatar src={logoUrl} alt={orgName} size="xl" className="mx-auto" />
+      <UserAvatar
+        src={logoUrl}
+        alt={orgName}
+        size="xl"
+        className="mx-auto"
+        borderTier={borderTier}
+        borderColor={borderColor}
+      />
       <div>
         <h1 className="text-2xl font-heading font-bold">{orgName}</h1>
         {description && <p className="text-gray-600 dark:text-gray-400 mt-1">{description}</p>}


### PR DESCRIPTION
Add awardOrganizerBorders() to seed script that awards Pioneer and organizer event count borders based on seeded activity, setting the highest-tier border as active. Update organizer profile page to fetch the active border and render it using UserAvatar.