### PR TITLE
perf: reduce image sizes and add cache headers for media

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -56,6 +56,15 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: "/media/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
     ];
   },
 };

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -181,6 +181,7 @@ export default async function Home() {
                   fill
                   sizes="(max-width: 1280px) 100vw, 1280px"
                   className="object-cover transition-transform duration-300 group-hover:scale-110"
+                  quality={50}
                   loading={i === 0 ? "eager" : "lazy"}
                 />
                 <div className="absolute inset-0 bg-black/40 group-hover:bg-black/30 transition-colors" />

--- a/src/components/landing/HeroCarousel.tsx
+++ b/src/components/landing/HeroCarousel.tsx
@@ -42,8 +42,10 @@ export default function HeroCarousel({ slides }: HeroCarouselProps) {
               alt={slide.image.alt || "Adventure"}
               fill
               className="object-cover"
-              sizes="100vw"
+              sizes="(max-width: 640px) 640px, (max-width: 1200px) 1200px, 1920px"
+              quality={50}
               priority={i === 0}
+              loading={i === 0 ? "eager" : "lazy"}
             />
           </div>
         );


### PR DESCRIPTION
- Lower hero carousel and category image quality to 50 (behind dark overlays, difference is invisible)
- Use responsive sizes hint on hero so mobile gets 640px, not 1920px
- Lazy-load non-first hero carousel slides
- Add immutable cache headers for /media/* (Payload CMS uploads)