### PR TITLE
perf: fix PageSpeed issues — defer GA, fix CLS, optimize images

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -96,8 +96,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         )}
         <link rel="preconnect" href="https://images.unsplash.com" />
       </head>
-      <GoogleAnalytics />
       <body className="font-sans min-h-screen flex flex-col">
+        <GoogleAnalytics />
         <ThemeProvider>
           <ClientShell initialNavLayout={navLayout}>{children}</ClientShell>
           <Footer />

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -28,27 +28,27 @@ const categories = [
   {
     name: "Hiking",
     slug: "hiking",
-    image: "https://images.unsplash.com/photo-1551632811-561732d1e306?w=1280&h=320&fit=crop",
+    image: "https://images.unsplash.com/photo-1551632811-561732d1e306?w=1280&h=200&fit=crop",
   },
   {
     name: "Mountain Biking",
     slug: "mtb",
-    image: "https://images.unsplash.com/photo-1544191696-102dbdaeeaa0?w=1280&h=320&fit=crop",
+    image: "https://images.unsplash.com/photo-1544191696-102dbdaeeaa0?w=1280&h=200&fit=crop",
   },
   {
     name: "Road Biking",
     slug: "road_bike",
-    image: "https://images.unsplash.com/photo-1541625602330-2277a4c46182?w=1280&h=320&fit=crop",
+    image: "https://images.unsplash.com/photo-1541625602330-2277a4c46182?w=1280&h=200&fit=crop",
   },
   {
     name: "Running",
     slug: "running",
-    image: "https://images.unsplash.com/photo-1552674605-db6ffd4facb5?w=1280&h=320&fit=crop",
+    image: "https://images.unsplash.com/photo-1552674605-db6ffd4facb5?w=1280&h=200&fit=crop",
   },
   {
     name: "Trail Running",
     slug: "trail_run",
-    image: "https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=1280&h=320&fit=crop",
+    image: "https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=1280&h=200&fit=crop",
   },
 ];
 
@@ -215,7 +215,7 @@ export default async function Home() {
                   src={cat.image}
                   alt={cat.name}
                   fill
-                  sizes="(max-width: 1280px) 100vw, 1280px"
+                  sizes="(max-width: 1280px) 95vw, 1280px"
                   className="object-cover transition-transform duration-300 group-hover:scale-110"
                   quality={50}
                   loading={i === 0 ? "eager" : "lazy"}

--- a/src/components/analytics/GoogleAnalytics.tsx
+++ b/src/components/analytics/GoogleAnalytics.tsx
@@ -7,11 +7,8 @@ export default function GoogleAnalytics() {
 
   return (
     <>
-      <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
-        strategy="afterInteractive"
-      />
-      <Script id="google-analytics" strategy="afterInteractive">
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} strategy="lazyOnload" />
+      <Script id="google-analytics" strategy="lazyOnload">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}

--- a/src/components/landing/HeroCarousel.tsx
+++ b/src/components/landing/HeroCarousel.tsx
@@ -42,7 +42,7 @@ export default function HeroCarousel({ slides }: HeroCarouselProps) {
               alt={slide.image.alt || "Adventure"}
               fill
               className="object-cover"
-              sizes="(max-width: 640px) 640px, (max-width: 1200px) 1200px, 1920px"
+              sizes="100vw"
               quality={50}
               priority={i === 0}
               loading={i === 0 ? "eager" : "lazy"}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,7 +1,18 @@
+import dynamic from "next/dynamic";
 import Link from "next/link";
 
 import HeroCarousel from "@/components/landing/HeroCarousel";
-import HostEventLink from "@/components/landing/HostEventLink";
+
+const HostEventLink = dynamic(() => import("@/components/landing/HostEventLink"), {
+  loading: () => (
+    <Link
+      href="/signup?role=organizer"
+      className="inline-flex items-center justify-center font-semibold rounded-xl text-lg py-4 px-8 border-2 border-gray-300 dark:border-slate-600 text-gray-600 dark:text-gray-300 hover:border-lime-500 hover:text-lime-600 dark:hover:text-lime-400 transition-colors"
+    >
+      Host Your Event
+    </Link>
+  ),
+});
 
 interface HeroSlide {
   image: { url: string; alt: string };
@@ -27,7 +38,7 @@ export default function HeroSection({ heroData }: HeroSectionProps) {
     : [];
 
   return (
-    <section className="relative py-24 sm:py-32 overflow-hidden min-h-[500px] flex items-center">
+    <section className="relative py-24 sm:py-32 overflow-hidden min-h-[500px] lg:min-h-[600px] flex items-center">
       {heroSlides.length > 0 ? (
         <HeroCarousel slides={heroSlides} />
       ) : (

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,11 @@
 {
+  "redirects": [
+    {
+      "source": "/:path(.*)",
+      "has": [{ "type": "host", "value": "eventtara.com" }],
+      "destination": "https://www.eventtara.com/:path",
+      "permanent": true
+    }
+  ],
   "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- src/ public/ next.config.mjs package.json package-lock.json tailwind.config.ts tsconfig.json"
 }


### PR DESCRIPTION
## Summary

Fixes multiple PageSpeed Insights issues identified via Lighthouse audit (mobile score: 67, desktop: 50).

- **Defer Google Analytics** from `afterInteractive` to `lazyOnload` — removes 61KB gtag.js from critical rendering path (~640ms savings)
- **Fix desktop CLS (0.612)** — move `<GoogleAnalytics />` from between `</head>` and `<body>` (invalid HTML causing browser reflow) to inside `<body>`
- **Code-split HostEventLink** — dynamically import with `next/dynamic` to defer ~38KB Supabase SDK from initial bundle
- **Optimize category images** — reduce Unsplash source height from 320px to 200px (cards are only 128–160px tall), saving ~124KB
- **Simplify hero `sizes`** — use `100vw` for full-bleed hero instead of breakpoint-based sizes that caused over-fetching
- **Stabilize hero height** — add `lg:min-h-[600px]` to prevent desktop layout shift
- **Add Vercel edge redirect** — `eventtara.com` → `www.eventtara.com` via `vercel.json` to eliminate redirect chain (~2s savings)

## Test plan

- [ ] Verify homepage loads correctly on mobile and desktop
- [ ] Verify hero carousel images display properly
- [ ] Verify "Host Your Event" button renders and links correctly
- [ ] Verify Google Analytics still fires (check Network tab for gtag after page idle)
- [ ] Run Lighthouse audit and confirm improved scores
- [ ] Confirm `eventtara.com` redirects cleanly to `www.eventtara.com` (after DNS update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)