### PR TITLE
fix: guard globalThis.location during SSR (fixes prod build)

### DIFF
--- a/src/components/landing/BetaNoticeModal.tsx
+++ b/src/components/landing/BetaNoticeModal.tsx
@@ -10,7 +10,11 @@ export default function BetaNoticeModal() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    if (new URLSearchParams(globalThis.location.search).has("lighthouse")) return;
+    if (
+      globalThis.location !== undefined &&
+      new URLSearchParams(globalThis.location.search).has("lighthouse")
+    )
+      return;
     try {
       const dismissed = sessionStorage.getItem(STORAGE_KEY);
       if (!dismissed) {

--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -57,6 +57,7 @@ export default function ClientShell({ children, initialNavLayout = "strip" }: Cl
   const isLighthouse = useMemo(
     () =>
       typeof globalThis !== "undefined" &&
+      globalThis.location !== undefined &&
       new URLSearchParams(globalThis.location.search).has("lighthouse"),
     [],
   );


### PR DESCRIPTION
## Summary

Fixes the production build failure introduced by #55. `globalThis.location` is `undefined` during Vercel static page generation, causing `TypeError: Cannot read properties of undefined (reading 'search')`.

Adds `globalThis.location !== undefined` guard in both `ClientShell` and `BetaNoticeModal` before accessing `.search`.

## Test plan

- [ ] Verify Vercel build succeeds
- [ ] Visit `/?lighthouse` — confirm DemoBanner and modal are suppressed
- [ ] Visit `/` normally — confirm everything works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)