### PR TITLE
fix: real-time check-in UI updates and organizer RLS policy

### DIFF
--- a/src/components/checkin/QRScanner.tsx
+++ b/src/components/checkin/QRScanner.tsx
@@ -76,6 +76,18 @@ export default function QRScanner({ eventId }: QRScannerProps) {
               message: data.message || data.error,
               userName: data.userName,
             });
+
+            // Notify CheckinList to update immediately
+            if (res.ok) {
+              globalThis.dispatchEvent(
+                new CustomEvent("checkin-success", {
+                  detail: {
+                    type: isCompanion ? "companion" : "user",
+                    id: isCompanion ? parts[4] : parts[3],
+                  },
+                }),
+              );
+            }
           } finally {
             // Allow next scan after a short delay
             setTimeout(() => {

--- a/supabase/migrations/20260227_organizer_checkin_policy.sql
+++ b/supabase/migrations/20260227_organizer_checkin_policy.sql
@@ -1,0 +1,9 @@
+-- Allow organizers to insert check-ins for participants of their events
+CREATE POLICY "Organizers can check in participants" ON public.event_checkins
+  FOR INSERT WITH CHECK (
+    event_id IN (
+      SELECT id FROM public.events WHERE organizer_id IN (
+        SELECT id FROM public.organizer_profiles WHERE user_id = auth.uid()
+      )
+    )
+  );


### PR DESCRIPTION
## Summary
- **Real-time check-in updates**: QRScanner dispatches a `checkin-success` CustomEvent after a successful scan, and CheckinList listens for it to update the participant list immediately — no page refresh needed. Supabase Realtime subscriptions remain as a fallback.
- **Organizer RLS policy**: Adds an INSERT policy on `event_checkins` so organizers can check in participants of their own events (previously blocked by RLS requiring `auth.uid() = user_id`).

## Test plan
- [ ] Scan a participant QR code on the check-in page — participant status should update to "Checked In" immediately
- [ ] Scan a companion QR code — companion status should also update instantly
- [ ] Verify the organizer can check in participants without RLS errors
- [ ] Verify the Realtime fallback still works if another device performs a check-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)