### PR TITLE
fix: wrap dashboard header buttons on mobile

### DIFF
--- a/src/app/(frontend)/(organizer)/dashboard/page.tsx
+++ b/src/app/(frontend)/(organizer)/dashboard/page.tsx
@@ -59,7 +59,7 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-8">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-heading font-bold dark:text-white">Dashboard</h1>
         <div className="flex items-center gap-2">
           <ScannerButton />


### PR DESCRIPTION
## Summary
- Add `flex-wrap` and `gap-3` to the dashboard header so the "Scan QR" and "Create Event" buttons wrap below the title on narrow screens instead of overlapping it

## Test plan
- [ ] View `/dashboard` on mobile viewport (~375px) — buttons should wrap below the "Dashboard" title
- [ ] View on desktop — layout unchanged, title and buttons on same row

🤖 Generated with [Claude Code](https://claude.com/claude-code)