### PR TITLE
fix: raise chat bubble and panel above navbar

### DIFF
--- a/src/components/chat/ChatBubble.tsx
+++ b/src/components/chat/ChatBubble.tsx
@@ -35,7 +35,7 @@ export default function ChatBubble() {
 
       <button
         onClick={handleToggle}
-        className={`fixed z-40 bottom-[5.5rem] right-4 md:bottom-6 md:right-6 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-all duration-300 active:scale-95 ${
+        className={`fixed z-[60] bottom-[5.5rem] right-4 md:bottom-6 md:right-6 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-all duration-300 active:scale-95 ${
           keyboardOpen ? "!hidden" : ""
         } ${
           open

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -178,7 +178,7 @@ export default function ChatPanel({ open, onClose, keyboard }: ChatPanelProps) {
 
   return (
     <div
-      className={`fixed z-40 transition-[opacity] duration-200 ease-out ${
+      className={`fixed z-[60] transition-[opacity] duration-200 ease-out ${
         open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
       } right-4 w-[calc(100vw-2rem)] max-w-[400px] ${keyboardOpen ? "" : "bottom-[9.5rem] h-[min(460px,calc(100vh-12rem))]"} md:bottom-6 md:right-[5.25rem] md:w-[400px] md:h-[min(500px,calc(100vh-6rem))]`}
       style={keyboardStyle}


### PR DESCRIPTION
## Summary
- Chat bubble and panel were `z-40`, below the navbar/mobile-nav at `z-50`
- This caused the nav to overlap the chat UI on `/events` and other pages
- Bumped both to `z-[60]` so the chat always renders above the navigation

## Test plan
- [ ] Open `/events` on mobile — tap chat bubble, verify panel is fully above the header and bottom nav
- [ ] Verify navbar still works correctly when chat is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)