### PR TITLE
fix: correct event_distances RLS policies

### DIFF
--- a/supabase/migrations/20260228_fix_event_distances_rls.sql
+++ b/supabase/migrations/20260228_fix_event_distances_rls.sql
@@ -1,0 +1,43 @@
+-- Fix event_distances RLS policies: organizer_id is organizer_profiles.id, not auth.uid()
+
+-- Drop broken policies
+DROP POLICY "event_distances_insert_organizer" ON event_distances;
+DROP POLICY "event_distances_update_organizer" ON event_distances;
+DROP POLICY "event_distances_delete_organizer" ON event_distances;
+
+-- Recreate with correct join through organizer_profiles
+CREATE POLICY "event_distances_insert_organizer"
+  ON event_distances FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM events
+      WHERE events.id = event_distances.event_id
+        AND events.organizer_id IN (
+          SELECT id FROM organizer_profiles WHERE user_id = auth.uid()
+        )
+    )
+  );
+
+CREATE POLICY "event_distances_update_organizer"
+  ON event_distances FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM events
+      WHERE events.id = event_distances.event_id
+        AND events.organizer_id IN (
+          SELECT id FROM organizer_profiles WHERE user_id = auth.uid()
+        )
+    )
+  );
+
+CREATE POLICY "event_distances_delete_organizer"
+  ON event_distances FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM events
+      WHERE events.id = event_distances.event_id
+        AND events.organizer_id IN (
+          SELECT id FROM organizer_profiles WHERE user_id = auth.uid()
+        )
+    )
+  );


### PR DESCRIPTION
## Summary
- Fix 3 broken RLS policies on `event_distances` table (INSERT, UPDATE, DELETE)
- The policies compared `events.organizer_id` directly to `auth.uid()`, but `organizer_id` stores `organizer_profiles.id` — they never match
- Now correctly joins through `organizer_profiles` to check `user_id = auth.uid()`, matching the pattern used by all other tables

## Root cause
`event_distances` migration used `events.organizer_id = auth.uid()` instead of the subquery pattern `events.organizer_id IN (SELECT id FROM organizer_profiles WHERE user_id = auth.uid())`.

## Impact
All organizers were blocked from creating/updating/deleting distance categories on running events.

## Test plan
- [ ] Run migration on Supabase
- [ ] Create a running event with distance categories — should succeed
- [ ] Edit distances on an existing event — should succeed
- [ ] Delete a distance category — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)