### PR TITLE
feat: add hover effects to badges and avatar borders

### DIFF
--- a/src/components/landing/GamificationSection.tsx
+++ b/src/components/landing/GamificationSection.tsx
@@ -57,7 +57,8 @@ export default async function GamificationSection() {
                 <div
                   key={badge.id}
                   className={cn(
-                    "flex flex-col items-center gap-3 rounded-2xl bg-gray-50 dark:bg-slate-700/50 p-5 transition-shadow",
+                    "flex flex-col items-center gap-3 rounded-2xl bg-gray-50 dark:bg-slate-700/50 p-5",
+                    "transition-all duration-200 hover:scale-105 hover:shadow-lg cursor-default",
                     style.ring,
                     style.glow,
                   )}
@@ -117,7 +118,10 @@ export default async function GamificationSection() {
           </h3>
           <div className="flex flex-wrap justify-center gap-8 sm:gap-12">
             {BORDER_TIERS.map((tier) => (
-              <div key={tier} className="flex flex-col items-center gap-3">
+              <div
+                key={tier}
+                className="flex flex-col items-center gap-3 transition-transform duration-200 hover:scale-110 cursor-default"
+              >
                 <UserAvatar alt={`${TIER_LABELS[tier]} border`} size="lg" borderTier={tier} />
                 <span
                   className={cn(


### PR DESCRIPTION
## Summary
- Add scale + shadow hover effects to badge cards in the gamification section
- Add scale hover effect to avatar border tier showcase

## Test plan
- [ ] Hover over badges on home page — should scale up 5% with shadow lift
- [ ] Hover over avatar border tiers — should scale up 10%
- [ ] Transitions should feel smooth (200ms)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)