### PR TITLE
fix: deduplicate feed items on pagination

### DIFF
--- a/src/components/feed/FeedList.tsx
+++ b/src/components/feed/FeedList.tsx
@@ -64,7 +64,11 @@ export default function FeedList({
         `/api/feed?offset=${String(items.length)}&limit=${String(BATCH_SIZE)}`,
       );
       const data: { items: FeedItem[]; hasMore: boolean } = await res.json();
-      setItems((prev) => [...prev, ...data.items]);
+      setItems((prev) => {
+        const existingKeys = new Set(prev.map((i) => i.feedKey));
+        const newItems = data.items.filter((i: FeedItem) => !existingKeys.has(i.feedKey));
+        return [...prev, ...newItems];
+      });
       setHasMore(data.hasMore);
       setInitialLoaded(true);
     } finally {


### PR DESCRIPTION
## Summary
- Deduplicate feed items by `feedKey` when appending new pages in `FeedList`
- Fixes React "duplicate key" console error when offset-based pagination returns overlapping items (e.g., new activity added between page loads)

## Test plan
- [ ] Open `/feed`, scroll to trigger infinite scroll pagination
- [ ] Verify no "duplicate key" console errors
- [ ] Repost an activity, refresh feed — no duplicates shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)