### PR TITLE
refactor: defer image upload until form submission

### DIFF
--- a/src/components/dashboard/BadgeForm.tsx
+++ b/src/components/dashboard/BadgeForm.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import { Button, Input } from "@/components/ui";
 import { BADGE_CATEGORIES, BADGE_RARITIES } from "@/lib/constants/badge-templates";
+import { uploadImage } from "@/lib/upload";
 
 import BadgeTemplatePicker from "./BadgeTemplatePicker";
 import PhotoUploader from "./PhotoUploader";
@@ -25,9 +26,10 @@ export default function BadgeForm({ eventId, existingBadge }: BadgeFormProps) {
   const router = useRouter();
   const [title, setTitle] = useState(existingBadge?.title || "");
   const [description, setDescription] = useState(existingBadge?.description || "");
-  const [imageUrl, setImageUrl] = useState<string | null>(existingBadge?.image_url || null);
+  const [imageUrl, setImageUrl] = useState<string | File | null>(existingBadge?.image_url || null);
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [error, setError] = useState("");
   const [category, setCategory] = useState(existingBadge?.category || "special");
   const [rarity, setRarity] = useState(existingBadge?.rarity || "common");
   const [showTemplatePicker, setShowTemplatePicker] = useState(!existingBadge);
@@ -48,6 +50,19 @@ export default function BadgeForm({ eventId, existingBadge }: BadgeFormProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+    setError("");
+
+    // Upload image if it's a pending File
+    let resolvedImageUrl: string | null = typeof imageUrl === "string" ? imageUrl : null;
+    if (imageUrl instanceof File) {
+      try {
+        resolvedImageUrl = await uploadImage(imageUrl, "badges/images");
+      } catch {
+        setError("Failed to upload badge image. Please try again.");
+        setLoading(false);
+        return;
+      }
+    }
 
     const res = await fetch("/api/badges", {
       method: "POST",
@@ -56,7 +71,7 @@ export default function BadgeForm({ eventId, existingBadge }: BadgeFormProps) {
         event_id: eventId,
         title,
         description,
-        image_url: imageUrl,
+        image_url: resolvedImageUrl,
         category,
         rarity,
       }),
@@ -103,9 +118,10 @@ export default function BadgeForm({ eventId, existingBadge }: BadgeFormProps) {
         />
 
         <PhotoUploader
-          folder="badges/images"
           value={imageUrl}
-          onChange={setImageUrl}
+          onChange={(file) => {
+            setImageUrl(file);
+          }}
           label="Badge Image"
         />
 
@@ -157,6 +173,7 @@ export default function BadgeForm({ eventId, existingBadge }: BadgeFormProps) {
           </div>
         </div>
 
+        {error && <p className="text-sm text-red-500">{error}</p>}
         {success && <p className="text-sm text-forest-500">Badge saved!</p>}
 
         <Button type="submit" size="sm" disabled={loading}>

--- a/src/components/dashboard/EventForm.tsx
+++ b/src/components/dashboard/EventForm.tsx
@@ -12,6 +12,7 @@ import { type EventDateInfo } from "@/components/ui/DateRangePicker";
 import { findProvinceFromLocation } from "@/lib/constants/philippine-provinces";
 import { rangesOverlap, getEffectiveEnd } from "@/lib/events/overlap";
 import { createClient } from "@/lib/supabase/client";
+import { uploadImage } from "@/lib/upload";
 
 import MountainCombobox, { type SelectedMountain } from "./MountainCombobox";
 import PhotoUploader from "./PhotoUploader";
@@ -272,7 +273,9 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
   const [location, setLocation] = useState(initialData?.location || "");
   const [maxParticipants, setMaxParticipants] = useState(initialData?.max_participants || 50);
   const [price, setPrice] = useState(initialData?.price || 0);
-  const [coverImage, setCoverImage] = useState<string | null>(initialData?.cover_image_url || null);
+  const [coverImage, setCoverImage] = useState<string | File | null>(
+    initialData?.cover_image_url || null,
+  );
   const [coordinates, setCoordinates] = useState<{ lat: number; lng: number } | null>(
     initialData?.coordinates || null,
   );
@@ -495,6 +498,18 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
       endDateTime = dateTimeEnd.toISOString();
     }
 
+    // Upload cover image if it's a pending File
+    let coverImageUrl: string | null = typeof coverImage === "string" ? coverImage : null;
+    if (coverImage instanceof File) {
+      try {
+        coverImageUrl = await uploadImage(coverImage, "events/covers");
+      } catch {
+        setError("Failed to upload cover image. Please try again.");
+        setLoading(false);
+        return;
+      }
+    }
+
     const body: Record<string, unknown> = {
       title,
       description,
@@ -505,7 +520,7 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
       coordinates,
       max_participants: maxParticipants,
       price,
-      cover_image_url: coverImage,
+      cover_image_url: coverImageUrl,
       difficulty_level: difficultyLevel,
     };
 
@@ -933,9 +948,10 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
       )}
 
       <PhotoUploader
-        folder="events/covers"
         value={coverImage}
-        onChange={setCoverImage}
+        onChange={(file) => {
+          setCoverImage(file);
+        }}
         label="Cover Image"
       />
 

--- a/src/components/dashboard/OrganizerProfileForm.tsx
+++ b/src/components/dashboard/OrganizerProfileForm.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import { Button, Input } from "@/components/ui";
 import { createClient } from "@/lib/supabase/client";
+import { uploadImage } from "@/lib/upload";
 
 import PhotoUploader from "./PhotoUploader";
 
@@ -22,19 +23,33 @@ export default function OrganizerProfileForm({ profile }: OrganizerProfileFormPr
   const supabase = createClient();
   const [orgName, setOrgName] = useState(profile?.org_name || "");
   const [description, setDescription] = useState(profile?.description || "");
-  const [logoUrl, setLogoUrl] = useState<string | null>(profile?.logo_url || null);
+  const [logoUrl, setLogoUrl] = useState<string | File | null>(profile?.logo_url || null);
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [error, setError] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setSuccess(false);
+    setError("");
+
+    // Upload logo if it's a pending File
+    let resolvedLogoUrl: string | null = typeof logoUrl === "string" ? logoUrl : null;
+    if (logoUrl instanceof File) {
+      try {
+        resolvedLogoUrl = await uploadImage(logoUrl, "organizers/logos");
+      } catch {
+        setError("Failed to upload logo. Please try again.");
+        setLoading(false);
+        return;
+      }
+    }
 
     if (profile) {
       await supabase
         .from("organizer_profiles")
-        .update({ org_name: orgName, description, logo_url: logoUrl })
+        .update({ org_name: orgName, description, logo_url: resolvedLogoUrl })
         .eq("id", profile.id);
     } else {
       const {
@@ -44,7 +59,7 @@ export default function OrganizerProfileForm({ profile }: OrganizerProfileFormPr
         user_id: user!.id,
         org_name: orgName,
         description,
-        logo_url: logoUrl,
+        logo_url: resolvedLogoUrl,
       });
       await supabase.from("users").update({ role: "organizer" }).eq("id", user!.id);
     }
@@ -82,8 +97,15 @@ export default function OrganizerProfileForm({ profile }: OrganizerProfileFormPr
         />
       </div>
 
-      <PhotoUploader folder="organizers/logos" value={logoUrl} onChange={setLogoUrl} label="Logo" />
+      <PhotoUploader
+        value={logoUrl}
+        onChange={(file) => {
+          setLogoUrl(file);
+        }}
+        label="Logo"
+      />
 
+      {error && <p className="text-sm text-red-500">{error}</p>}
       {success && <p className="text-sm text-forest-500">Profile saved!</p>}
 
       <Button type="submit" disabled={loading}>

--- a/src/components/dashboard/PhotoUploader.tsx
+++ b/src/components/dashboard/PhotoUploader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 
 import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
@@ -58,59 +58,57 @@ async function compressImage(file: File): Promise<File> {
 }
 
 interface PhotoUploaderProps {
-  folder: string;
-  value: string | null;
-  onChange: (url: string | null) => void;
+  value: string | File | null;
+  onChange: (value: File | null) => void;
   label?: string;
 }
 
-export default function PhotoUploader({ folder, value, onChange, label }: PhotoUploaderProps) {
+export default function PhotoUploader({ value, onChange, label }: PhotoUploaderProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [uploading, setUploading] = useState(false);
+  const [compressing, setCompressing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
-  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  // Generate / revoke object URL for File previews
+  useEffect(() => {
+    if (value instanceof File) {
+      const url = URL.createObjectURL(value);
+      setPreviewUrl(url);
+      return () => {
+        URL.revokeObjectURL(url);
+      };
+    }
+    // For string URLs or null, use the value directly
+    setPreviewUrl(typeof value === "string" ? value : null);
+  }, [value]);
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    // Reset input so the same file can be re-selected
+    e.target.value = "";
+
     setError(null);
-    setUploading(true);
+    setCompressing(true);
 
     let compressed: File;
     try {
       compressed = await compressImage(file);
     } catch {
       setError("Could not process image. Please try a different file.");
-      setUploading(false);
+      setCompressing(false);
       return;
     }
 
     if (compressed.size > MAX_SIZE_BYTES) {
       setError("Image is too large even after compression. Please use a smaller image.");
-      setUploading(false);
+      setCompressing(false);
       return;
     }
 
-    const body = new FormData();
-    body.append("file", compressed);
-    body.append("folder", folder);
-
-    try {
-      const res = await fetch("/api/upload", { method: "POST", body });
-      const data = await res.json();
-
-      if (!res.ok) {
-        setError(data.error || "Upload failed");
-        setUploading(false);
-        return;
-      }
-
-      onChange(data.url);
-    } catch {
-      setError("Upload failed. Please try again.");
-    } finally {
-      setUploading(false);
-    }
+    setCompressing(false);
+    onChange(compressed);
   };
 
   return (
@@ -124,19 +122,25 @@ export default function PhotoUploader({ folder, value, onChange, label }: PhotoU
         onClick={() => inputRef.current?.click()}
         className={cn(
           "border-2 border-dashed rounded-xl p-4 text-center cursor-pointer transition-colors",
-          value
+          previewUrl
             ? "border-forest-300 bg-forest-50"
             : "border-gray-300 dark:border-gray-600 hover:border-lime-300",
         )}
       >
-        {value ? (
+        {previewUrl ? (
           <div className="relative w-full h-40">
-            <Image src={value} alt="Upload preview" fill className="object-cover rounded-lg" />
+            <Image
+              src={previewUrl}
+              alt="Upload preview"
+              fill
+              className="object-cover rounded-lg"
+              unoptimized={value instanceof File}
+            />
           </div>
         ) : (
           <div className="py-8">
             <p className="text-gray-500 dark:text-gray-400">
-              {uploading ? "Compressing & uploading..." : "Click to upload image"}
+              {compressing ? "Compressing..." : "Click to upload image"}
             </p>
             <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
               Max 1 MB · auto-compressed to JPEG
@@ -149,7 +153,7 @@ export default function PhotoUploader({ folder, value, onChange, label }: PhotoU
         type="file"
         accept="image/*"
         className="hidden"
-        onChange={handleUpload}
+        onChange={handleFileSelect}
       />
       {error && <p className="text-sm text-red-500">{error}</p>}
       {value && (

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -1,0 +1,14 @@
+export async function uploadImage(file: File, folder: string): Promise<string> {
+  const body = new FormData();
+  body.append("file", file);
+  body.append("folder", folder);
+
+  const res = await fetch("/api/upload", { method: "POST", body });
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error(data.error || "Upload failed");
+  }
+
+  return data.url as string;
+}


### PR DESCRIPTION
## Summary
- **Extract `uploadImage()` utility** (`src/lib/upload.ts`) — reusable helper that POSTs a File to `/api/upload` and returns the URL
- **Refactor PhotoUploader to picker + preview only** — no longer uploads on file select; compresses the image and keeps the `File` in memory with a local `blob:` preview (cleaned up via `useEffect`)
- **Defer actual upload to form submit** in EventForm, BadgeForm, and OrganizerProfileForm — eliminates orphaned R2 objects from abandoned forms

## Test plan
- [ ] Create event with cover image: preview shows immediately, no `/api/upload` network request until form submit
- [ ] Submit form → image uploads → event created with correct `cover_image_url`
- [ ] Edit event with existing cover image → existing URL preview shown, no re-upload on save
- [ ] Remove image before submit → no upload occurs
- [ ] Same flow works for badge images and organizer logos
- [ ] Upload failure on submit shows error message, form stays editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)