### PR TITLE
fix: collapse Coco bubble to circle after 5s

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -132,9 +132,7 @@
 }
 
 .animate-chat-bubble-in {
-  animation:
-    chatBubbleIn 0.3s ease-out forwards,
-    chatBubbleNudge 6s ease-in-out 5s 2;
+  animation: chatBubbleIn 0.3s ease-out forwards;
 }
 
 .animate-chat-message-in {

--- a/src/components/chat/ChatBubble.tsx
+++ b/src/components/chat/ChatBubble.tsx
@@ -8,8 +8,8 @@ import { useKeyboardHeight } from "@/lib/hooks/useKeyboardHeight";
 
 import ChatPanel from "./ChatPanel";
 
-/** Collapse pill to circle after intro + 2 nudges (~17s) */
-const COLLAPSE_DELAY = 17_000;
+/** Collapse pill to circle after 5 seconds */
+const COLLAPSE_DELAY = 5_000;
 
 export default function ChatBubble() {
   const pathname = usePathname();


### PR DESCRIPTION
## Summary
- Reduce collapse delay from 17s to 5s so the pill shrinks to a circle faster
- Remove nudge animation (no time to play before collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)