### PR TITLE
fix: add cache headers for R2 images

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -61,12 +61,27 @@ const nextConfig = {
         destination: `${supabaseUrl}/storage/v1/object/public/:path*`,
       });
     }
+    if (r2PublicUrl) {
+      rules.push({
+        source: "/r2/:path*",
+        destination: `${r2PublicUrl}/:path*`,
+      });
+    }
     return rules;
   },
   async headers() {
     return [
       {
         source: "/storage/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/r2/:path*",
         headers: [
           {
             key: "Cache-Control",

--- a/src/app/(frontend)/(participant)/events/[id]/page.tsx
+++ b/src/app/(frontend)/(participant)/events/[id]/page.tsx
@@ -14,6 +14,7 @@ import ReviewForm from "@/components/reviews/ReviewForm";
 import ReviewList from "@/components/reviews/ReviewList";
 import { UIBadge } from "@/components/ui";
 import { resolvePresetImage } from "@/lib/constants/avatars";
+import { cdnUrl } from "@/lib/storage";
 import { createClient } from "@/lib/supabase/server";
 import { formatEventDate } from "@/lib/utils/format-date";
 
@@ -416,7 +417,12 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
       {/* Hero Image */}
       <div className="relative h-64 md:h-96 rounded-2xl overflow-hidden bg-gradient-to-br from-lime-100 to-forest-100 dark:from-lime-900 dark:to-forest-900 mb-8">
         {event.cover_image_url && (
-          <Image src={event.cover_image_url} alt={event.title} fill className="object-cover" />
+          <Image
+            src={cdnUrl(event.cover_image_url) ?? event.cover_image_url}
+            alt={event.title}
+            fill
+            className="object-cover"
+          />
         )}
       </div>
 
@@ -446,7 +452,12 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
             </div>
           )}
 
-          <EventGallery photos={photos || []} />
+          <EventGallery
+            photos={(photos || []).map((p) => ({
+              ...p,
+              image_url: cdnUrl(p.image_url) ?? p.image_url,
+            }))}
+          />
 
           {event.coordinates &&
             typeof event.coordinates === "object" &&

--- a/src/lib/events/map-event-card.ts
+++ b/src/lib/events/map-event-card.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+import { cdnUrl } from "@/lib/storage";
 import type { Database } from "@/lib/supabase/types";
 
 export interface EventCardData {
@@ -107,7 +108,7 @@ export function mapEventToCard(
     endDate: event.end_date,
     location: event.location,
     price: Number(event.price),
-    cover_image_url: event.cover_image_url,
+    cover_image_url: cdnUrl(event.cover_image_url) ?? event.cover_image_url,
     max_participants: event.max_participants,
     booking_count: event.bookings?.[0]?.count || 0,
     status: getEventStatus(event.date, today),

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -30,7 +30,10 @@ export async function uploadToR2(
 
   const res = await getR2Client().fetch(url, {
     method: "PUT",
-    headers: { "Content-Type": contentType },
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
     body: new Uint8Array(body),
   });
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,22 +1,41 @@
 /**
- * Convert a Supabase storage public URL to a CDN-proxied path.
+ * Convert a Supabase storage or R2 public URL to a CDN-proxied path.
  *
- * Input:  https://xxx.supabase.co/storage/v1/object/public/covers/photo.jpg
- * Output: /storage/covers/photo.jpg
+ * Supabase:
+ *   Input:  https://xxx.supabase.co/storage/v1/object/public/covers/photo.jpg
+ *   Output: /storage/covers/photo.jpg
+ *
+ * R2:
+ *   Input:  https://pub-xxx.r2.dev/events/photo.jpg
+ *   Output: /r2/events/photo.jpg
  *
  * This routes through our own domain (Vercel/Cloudflare edge) instead of
- * hitting Supabase storage directly, reducing Supabase bandwidth usage.
- * The /storage/* rewrite in next.config.mjs proxies back to Supabase with
- * a 1-year Cache-Control header.
+ * hitting storage directly, reducing bandwidth usage.
+ * The /storage/* and /r2/* rewrites in next.config.mjs proxy back to the
+ * origin with a 1-year Cache-Control header.
  */
 export function cdnUrl(url: string | null | undefined): string | null {
   if (!url) return null;
 
+  // Supabase storage
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  if (!supabaseUrl) return url;
+  if (supabaseUrl) {
+    const storagePrefix = `${supabaseUrl}/storage/v1/object/public/`;
+    if (url.startsWith(storagePrefix)) {
+      return `/storage/${url.slice(storagePrefix.length)}`;
+    }
+  }
 
-  const storagePrefix = `${supabaseUrl}/storage/v1/object/public/`;
-  if (!url.startsWith(storagePrefix)) return url;
+  // Cloudflare R2 — detect by pattern so it works in client components too
+  const r2PublicUrl = process.env.R2_PUBLIC_URL;
+  if (r2PublicUrl && url.startsWith(r2PublicUrl)) {
+    return `/r2/${url.slice(r2PublicUrl.length + 1)}`;
+  }
+  const r2Regex = /^https:\/\/pub-[a-f0-9]+\.r2\.dev\/(.+)$/;
+  const r2Match = r2Regex.exec(url);
+  if (r2Match) {
+    return `/r2/${r2Match[1]}`;
+  }
 
-  return `/storage/${url.slice(storagePrefix.length)}`;
+  return url;
 }


### PR DESCRIPTION
## Summary
- R2-served images had **no Cache-Control header**, causing Lighthouse to flag "Use efficient cache lifetimes" (est. savings 1,409 KiB)
- Set `Cache-Control: public, max-age=31536000, immutable` on R2 uploads for all future images
- Add `/r2/*` rewrite in `next.config.mjs` to proxy R2 images through Next.js with 1-year cache headers (same pattern as existing Supabase `/storage/*` proxy)
- Update `cdnUrl()` to convert R2 public URLs (`pub-*.r2.dev`) to proxied `/r2/` paths
- Apply `cdnUrl()` in the event card mapper and event detail page (cover image + gallery photos)

## Test plan
- [ ] Verify event cover images load via `/r2/` path instead of raw R2 URL
- [ ] Check `Cache-Control` header is present on `/r2/*` responses
- [ ] Upload a new event cover image and confirm it gets the cache header at the R2 level
- [ ] Run Lighthouse and confirm "Use efficient cache lifetimes" no longer flags R2 images

🤖 Generated with [Claude Code](https://claude.com/claude-code)