### PR TITLE
fix: use dvh units instead of vh for mobile viewport accuracy

### DIFF
--- a/src/app/(frontend)/(auth)/layout.tsx
+++ b/src/app/(frontend)/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-800 flex items-center justify-center p-4">
+    <div className="min-h-dvh bg-gray-50 dark:bg-gray-800 flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <h1

--- a/src/app/(frontend)/(organizer)/dashboard/layout.tsx
+++ b/src/app/(frontend)/(organizer)/dashboard/layout.tsx
@@ -23,7 +23,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
   return (
     <div className="flex">
       <DashboardSidebar />
-      <main className="flex-1 min-w-0 p-4 md:p-8 bg-gray-50 dark:bg-gray-950 min-h-[calc(100vh-4rem)]">
+      <main className="flex-1 min-w-0 p-4 md:p-8 bg-gray-50 dark:bg-gray-950 min-h-[calc(100dvh-4rem)]">
         {children}
       </main>
       <ScannerFAB />

--- a/src/app/(frontend)/(participant)/contact/page.tsx
+++ b/src/app/(frontend)/(participant)/contact/page.tsx
@@ -40,7 +40,7 @@ export default function ContactPage() {
   }
 
   return (
-    <main className="py-20 bg-gray-50 dark:bg-slate-900 min-h-screen">
+    <main className="py-20 bg-gray-50 dark:bg-slate-900 min-h-dvh">
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
         <h1 className="text-4xl sm:text-5xl font-heading font-bold text-gray-900 dark:text-white mb-4">
           Contact Us

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -146,7 +146,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           }}
         />
       </head>
-      <body className="font-sans min-h-screen flex flex-col">
+      <body className="font-sans min-h-dvh flex flex-col">
         <GoogleAnalytics />
         <ThemeProvider>
           <ClientShell initialNavLayout={navLayout} activityFeedEnabled={activityFeedEnabled}>

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -182,7 +182,7 @@ export default function ChatPanel({ open, onClose, keyboard }: ChatPanelProps) {
         open
           ? "opacity-100 pointer-events-auto translate-y-0"
           : "opacity-0 pointer-events-none translate-y-2"
-      } right-4 w-[calc(100vw-2rem)] max-w-[400px] ${keyboardOpen ? "" : "bottom-[9.5rem] h-[min(460px,calc(100vh-12rem))]"} md:bottom-6 md:right-[5.25rem] md:w-[400px] md:h-[min(500px,calc(100vh-6rem))]`}
+      } right-4 w-[calc(100vw-2rem)] max-w-[400px] ${keyboardOpen ? "" : "bottom-[9.5rem] h-[min(460px,calc(100dvh-12rem))]"} md:bottom-6 md:right-[5.25rem] md:w-[400px] md:h-[min(500px,calc(100dvh-6rem))]`}
       style={keyboardStyle}
     >
       <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900">

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -16,7 +16,7 @@ export default function DashboardSidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="w-64 bg-white dark:bg-gray-900 border-r border-gray-100 dark:border-gray-800 min-h-[calc(100vh-4rem)] p-4 hidden md:block">
+    <aside className="w-64 bg-white dark:bg-gray-900 border-r border-gray-100 dark:border-gray-800 min-h-[calc(100dvh-4rem)] p-4 hidden md:block">
       <nav className="space-y-1">
         {NAV_ITEMS.map((item) => {
           const isActive =

--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -213,7 +213,7 @@ export default function ClientShell({
     <>
       <OfflineIndicator />
       <div
-        className={`transition-all duration-300 origin-top min-h-screen flex flex-col ${
+        className={`transition-all duration-300 origin-top min-h-dvh flex flex-col ${
           drawerOpen ? "scale-[0.95] opacity-50 rounded-xl overflow-hidden pointer-events-none" : ""
         }`}
       >


### PR DESCRIPTION
## Summary
- Replaces `vh` / `min-h-screen` with `dvh` / `min-h-dvh` across layouts and components so heights account for mobile browser chrome (address bar, bottom bar)
- Affects auth layout, dashboard layout, contact page, root frontend layout, chat panel, dashboard sidebar, and client shell

## Test plan
- [ ] Open the app on a mobile browser (iOS Safari, Chrome Android) and verify pages fill the viewport correctly without overscroll behind the address bar
- [ ] Verify desktop browsers render identically (dvh falls back to vh on desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)