### PR TITLE
fix(strava): guard against missing service role key in OAuth callback

### DIFF
--- a/src/app/(frontend)/auth/strava/callback/route.ts
+++ b/src/app/(frontend)/auth/strava/callback/route.ts
@@ -80,6 +80,12 @@ export async function GET(request: Request) {
   }
 
   const { athlete, access_token, refresh_token, expires_at } = tokenData;
+
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    console.error("[Strava Callback] Missing SUPABASE_SERVICE_ROLE_KEY");
+    return NextResponse.redirect(`${origin}/login?error=strava_config`);
+  }
+
   const serviceClient = createServiceClient();
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds an env var check for `SUPABASE_SERVICE_ROLE_KEY` before calling `createServiceClient()` in the Strava OAuth callback
- Prevents a raw HTTP 500 crash by redirecting to `/login?error=strava_config` instead

## Context
The Strava OAuth callback was returning a 500 in production because `SUPABASE_SERVICE_ROLE_KEY` was not set in Vercel environment variables. The `createServiceClient()` constructor throws when the key is `undefined`, and there was no guard or try/catch around it.

## Test plan
- [ ] Verify Strava login flow works with `SUPABASE_SERVICE_ROLE_KEY` set
- [ ] Verify graceful redirect when `SUPABASE_SERVICE_ROLE_KEY` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)