### PR TITLE
fix: resolve hydration mismatch in ShareButtons

### DIFF
--- a/src/components/events/ShareButtons.tsx
+++ b/src/components/events/ShareButtons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { CheckIcon, FacebookIcon, LinkIcon, ShareIcon, XTwitterIcon } from "@/components/icons";
 
@@ -11,6 +11,11 @@ interface ShareButtonsProps {
 
 export default function ShareButtons({ title, eventId }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
+  const [canNativeShare, setCanNativeShare] = useState(false);
+
+  useEffect(() => {
+    setCanNativeShare(typeof navigator !== "undefined" && "share" in navigator);
+  }, []);
 
   const getUrl = useCallback(() => {
     return `${globalThis.location.origin}/events/${eventId}`;
@@ -89,7 +94,7 @@ export default function ShareButtons({ title, eventId }: ShareButtonsProps) {
       </button>
 
       {/* Native share (mobile) */}
-      {typeof navigator !== "undefined" && "share" in navigator && (
+      {canNativeShare && (
         <button onClick={nativeShare} className={btnClass} title="Share">
           <ShareIcon className="w-5 h-5" />
         </button>


### PR DESCRIPTION
## Summary
- Moves `navigator.share` detection into `useEffect` so server and client render identical initial HTML
- Fixes React hydration warning on event detail pages

## Test plan
- [ ] Open any event detail page — no hydration mismatch warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)