### PR TITLE
feat: full-screen navigation loader with pulsing logo

### DIFF
--- a/docs/plans/2026-03-05-navigation-loader-design.md
+++ b/docs/plans/2026-03-05-navigation-loader-design.md
@@ -1,0 +1,44 @@
+# Navigation Loading Overlay — Full-Screen Logo Pulse
+
+**Date:** 2026-03-05
+**Status:** Approved
+**Approach:** A — `usePathname()` route change detection in ClientShell, zero dependencies
+
+## Problem
+
+When clicking links on EventTara, there's a perceived delay where nothing visually happens while the next page loads. Users need immediate visual feedback.
+
+## Design
+
+### Architecture
+
+- **`NavigationContext`** — React context providing `{ isNavigating, startNavigation }`
+- **`NavigationProvider`** — wraps app inside ClientShell, listens to `usePathname()` to auto-clear loading state
+- **`NavigationLoader`** — full-screen overlay (favicon + "EventTara" text, pulsing)
+- **`NavLink`** — thin wrapper around `next/link` that calls `startNavigation()` on click
+
+### Behavior
+
+1. User clicks `NavLink` → `startNavigation()` called
+2. After 150ms delay, if still navigating → show overlay with fade-in
+3. Overlay: semi-transparent backdrop, centered favicon + "EventTara" text with pulse animation
+4. `pathname` changes → idle → overlay fades out
+5. Safety timeout (8s): auto-hide if navigation stalls
+
+### Overlay Visual
+
+- Fixed fullscreen, `z-[60]` (above navbar z-50)
+- Backdrop: `bg-white/80 dark:bg-gray-950/80` + `backdrop-blur-sm`
+- Center: favicon (48x48) + "EventTara" lime-500 cursive
+- Pulse: `scale(0.95→1.05)` + `opacity(0.6→1)`, 1.2s infinite
+- Fade in/out: 200ms ease
+
+### Files
+
+- **New:** `src/components/navigation/NavigationContext.tsx`
+- **New:** `src/components/navigation/NavigationLoader.tsx`
+- **Modify:** `src/components/layout/ClientShell.tsx` — add NavigationProvider + NavigationLoader
+- **Modify:** `src/components/layout/Navbar.tsx` — use NavLink
+- **Modify:** `src/components/layout/MobileNav.tsx` — use NavLink
+- **Modify:** `tailwind.config.ts` — add logoPulse animation
+- **Audit:** Other Link usages site-wide

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
-import Link from "next/link";
 
+import { NavLink } from "@/components/navigation/NavigationContext";
 import { Card, UIBadge } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { formatEventDate } from "@/lib/utils/format-date";
@@ -65,7 +65,7 @@ export default function EventCard({
   const formattedDate = formatEventDate(date, endDate, { short: true });
 
   return (
-    <Link href={`/events/${id}`}>
+    <NavLink href={`/events/${id}`}>
       <Card
         className={cn(
           "overflow-hidden cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700",
@@ -188,6 +188,6 @@ export default function EventCard({
           </div>
         </div>
       </Card>
-    </Link>
+    </NavLink>
   );
 }

--- a/src/components/layout/ActivityCard.tsx
+++ b/src/components/layout/ActivityCard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 
+import { NavLink } from "@/components/navigation/NavigationContext";
 import { cn } from "@/lib/utils";
 
 interface ActivityCardProps {
@@ -15,7 +15,7 @@ interface ActivityCardProps {
 
 export default function ActivityCard({ slug, label, icon, image, className }: ActivityCardProps) {
   return (
-    <Link
+    <NavLink
       href={`/events?type=${slug}`}
       className={cn("group relative overflow-hidden rounded-xl block", className)}
     >
@@ -33,6 +33,6 @@ export default function ActivityCard({ slug, label, icon, image, className }: Ac
         <span className="text-lg">{icon}</span>
         <span className="text-white font-semibold text-sm drop-shadow-md">{label}</span>
       </div>
-    </Link>
+    </NavLink>
   );
 }

--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -7,6 +7,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import MobileNav from "@/components/layout/MobileNav";
 import Navbar from "@/components/layout/Navbar";
+import { NavigationProvider } from "@/components/navigation/NavigationContext";
+import NavigationLoader from "@/components/navigation/NavigationLoader";
 import OfflineIndicator from "@/components/pwa/OfflineIndicator";
 import type { BorderTier } from "@/lib/constants/avatar-borders";
 import { BreadcrumbProvider } from "@/lib/contexts/BreadcrumbContext";
@@ -211,8 +213,9 @@ export default function ClientShell({
   const handleMenuOpen = useCallback(() => setDrawerOpen(true), []);
 
   return (
-    <>
+    <NavigationProvider>
       <OfflineIndicator />
+      <NavigationLoader />
       <div
         className={`transition-all duration-300 origin-top min-h-dvh flex flex-col ${
           drawerOpen ? "scale-[0.95] opacity-50 rounded-xl overflow-hidden pointer-events-none" : ""
@@ -250,6 +253,6 @@ export default function ClientShell({
 
       <ChatBubble />
       <InstallPrompt />
-    </>
+    </NavigationProvider>
   );
 }

--- a/src/components/layout/ExploreDropdown.tsx
+++ b/src/components/layout/ExploreDropdown.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 
 import ActivityCard from "@/components/layout/ActivityCard";
+import { NavLink } from "@/components/navigation/NavigationContext";
 
 interface Activity {
   slug: string;
@@ -22,9 +22,9 @@ interface ExploreDropdownProps extends LayoutProps {
 
 function AllEventsLink({ className }: { className?: string }) {
   return (
-    <Link href="/events" className={className}>
+    <NavLink href="/events" className={className}>
       All Events
-    </Link>
+    </NavLink>
   );
 }
 

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import type { User } from "@supabase/supabase-js";
-import Link from "next/link";
 import { useEffect, useRef } from "react";
 
 import { CloseIcon } from "@/components/icons";
 import ActivityCard from "@/components/layout/ActivityCard";
+import { NavLink } from "@/components/navigation/NavigationContext";
 
 interface Activity {
   slug: string;
@@ -86,13 +86,13 @@ export default function MobileDrawer({
         <div className="overflow-y-auto h-[calc(100%-65px)] p-4 space-y-4">
           {/* Explore Events section */}
           <div>
-            <Link
+            <NavLink
               href="/events"
               onClick={onClose}
               className="block text-sm font-semibold text-gray-900 dark:text-white mb-2"
             >
               Explore Events
-            </Link>
+            </NavLink>
             <div className="space-y-2">
               {activities.map((activity) => (
                 <div key={activity.slug} onClick={onClose}>
@@ -109,35 +109,35 @@ export default function MobileDrawer({
           {user ? (
             <div className="space-y-1">
               {role === "organizer" && (
-                <Link
+                <NavLink
                   href="/dashboard"
                   onClick={onClose}
                   className="block px-4 py-3 rounded-xl text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 font-medium"
                 >
                   Dashboard
-                </Link>
+                </NavLink>
               )}
-              <Link
+              <NavLink
                 href="/profile"
                 onClick={onClose}
                 className="block px-4 py-3 rounded-xl text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 font-medium"
               >
                 Profile
-              </Link>
-              <Link
+              </NavLink>
+              <NavLink
                 href="/my-events"
                 onClick={onClose}
                 className="block px-4 py-3 rounded-xl text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 font-medium"
               >
                 My Events
-              </Link>
-              <Link
+              </NavLink>
+              <NavLink
                 href="/notifications"
                 onClick={onClose}
                 className="block px-4 py-3 rounded-xl text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 font-medium"
               >
                 Notifications
-              </Link>
+              </NavLink>
               <button
                 onClick={() => {
                   onClose();
@@ -150,27 +150,27 @@ export default function MobileDrawer({
             </div>
           ) : (
             <div className="space-y-2">
-              <Link
+              <NavLink
                 href="/signup?role=organizer"
                 onClick={onClose}
                 className="block px-4 py-3 rounded-xl text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 font-medium text-center"
               >
                 Host Your Event
-              </Link>
-              <Link
+              </NavLink>
+              <NavLink
                 href="/login"
                 onClick={onClose}
                 className="block px-4 py-3 rounded-xl text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 font-medium text-center"
               >
                 Sign In
-              </Link>
-              <Link
+              </NavLink>
+              <NavLink
                 href="/signup"
                 onClick={onClose}
                 className="block px-4 py-3 rounded-xl bg-lime-500 text-gray-900 hover:bg-lime-400 font-semibold text-center"
               >
                 Get Started
-              </Link>
+              </NavLink>
             </div>
           )}
         </div>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { User } from "@supabase/supabase-js";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import {
@@ -14,6 +13,7 @@ import {
   LoginIcon,
   ProfileIcon,
 } from "@/components/icons";
+import { NavLink } from "@/components/navigation/NavigationContext";
 import { useKeyboardHeight } from "@/lib/hooks/useKeyboardHeight";
 import { cn } from "@/lib/utils";
 
@@ -146,7 +146,7 @@ export default function MobileNav({ user, role, activityFeedEnabled = false }: M
           const active = item.isActive(pathname);
           const Icon = item.icon;
           return (
-            <Link
+            <NavLink
               key={item.href}
               href={item.href}
               className={cn(
@@ -158,7 +158,7 @@ export default function MobileNav({ user, role, activityFeedEnabled = false }: M
               <span className={cn("text-[11px]", active ? "font-semibold" : "font-medium")}>
                 {item.label}
               </span>
-            </Link>
+            </NavLink>
           );
         })}
       </div>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,13 +3,13 @@
 import type { User } from "@supabase/supabase-js";
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 
 import { ChevronDownIcon, MenuIcon } from "@/components/icons";
 import ExploreDropdown from "@/components/layout/ExploreDropdown";
 import ThemeToggle from "@/components/layout/ThemeToggle";
+import { NavLink } from "@/components/navigation/NavigationContext";
 import { UserAvatar, Button } from "@/components/ui";
 import type { BorderTier } from "@/lib/constants/avatar-borders";
 
@@ -87,7 +87,7 @@ export default function Navbar({
     <nav className="bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
-          <Link href="/" className="flex items-center gap-2">
+          <NavLink href="/" className="flex items-center gap-2">
             <Image
               src="/favicon-192x192.png"
               alt="EventTara"
@@ -104,7 +104,7 @@ export default function Navbar({
             <span className="bg-lime-500 text-gray-900 text-xs px-2 py-0.5 rounded-full font-medium">
               BETA
             </span>
-          </Link>
+          </NavLink>
 
           {/* Desktop nav */}
           <div className="hidden md:flex items-center gap-6">
@@ -132,12 +132,12 @@ export default function Navbar({
               )}
             </div>
             {activityFeedEnabled && (
-              <Link
+              <NavLink
                 href="/feed"
                 className={`text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white font-medium ${pathname === "/feed" ? "text-lime-600 dark:text-lime-400" : ""}`}
               >
                 Feed
-              </Link>
+              </NavLink>
             )}
             {loading ? (
               <div className="w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-800 animate-pulse" />
@@ -173,25 +173,25 @@ export default function Navbar({
                         </p>
                       </div>
                       {role === "organizer" && (
-                        <Link
+                        <NavLink
                           href="/dashboard"
                           className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
                         >
                           Dashboard
-                        </Link>
+                        </NavLink>
                       )}
-                      <Link
+                      <NavLink
                         href="/profile"
                         className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
                       >
                         Profile
-                      </Link>
-                      <Link
+                      </NavLink>
+                      <NavLink
                         href="/my-events"
                         className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
                       >
                         My Events
-                      </Link>
+                      </NavLink>
                       <button
                         onClick={() => {
                           setProfileOpen(false);
@@ -219,14 +219,14 @@ export default function Navbar({
               </div>
             ) : (
               <div className="flex items-center gap-3">
-                <Link href="/login">
+                <NavLink href="/login">
                   <Button variant="ghost" size="sm">
                     Sign In
                   </Button>
-                </Link>
-                <Link href="/signup">
+                </NavLink>
+                <NavLink href="/signup">
                   <Button size="sm">Sign Up</Button>
-                </Link>
+                </NavLink>
               </div>
             )}
           </div>

--- a/src/components/navigation/NavigationContext.tsx
+++ b/src/components/navigation/NavigationContext.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface NavigationContextValue {
+  isNavigating: boolean;
+  startNavigation: () => void;
+}
+
+const noop = () => {
+  /* default no-op — overridden by NavigationProvider */
+};
+
+const NavigationContext = createContext<NavigationContextValue>({
+  isNavigating: false,
+  startNavigation: noop,
+});
+
+export function useNavigation() {
+  return useContext(NavigationContext);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+const SAFETY_TIMEOUT_MS = 8000;
+
+export function NavigationProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const [isNavigating, setIsNavigating] = useState(false);
+  const safetyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevPathname = useRef(pathname);
+
+  const startNavigation = useCallback(() => {
+    setIsNavigating(true);
+    // Safety: auto-clear if navigation stalls
+    if (safetyTimer.current) clearTimeout(safetyTimer.current);
+    safetyTimer.current = setTimeout(() => {
+      setIsNavigating(false);
+    }, SAFETY_TIMEOUT_MS);
+  }, []);
+
+  // Clear navigation state when pathname actually changes
+  useEffect(() => {
+    if (pathname !== prevPathname.current) {
+      prevPathname.current = pathname;
+      setIsNavigating(false);
+      if (safetyTimer.current) {
+        clearTimeout(safetyTimer.current);
+        safetyTimer.current = null;
+      }
+    }
+  }, [pathname]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (safetyTimer.current) clearTimeout(safetyTimer.current);
+    };
+  }, []);
+
+  return (
+    <NavigationContext.Provider value={{ isNavigating, startNavigation }}>
+      {children}
+    </NavigationContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NavLink — drop-in replacement for next/link with navigation tracking
+// ---------------------------------------------------------------------------
+
+type NavLinkProps = React.ComponentProps<typeof Link>;
+
+const NavLink = forwardRef<HTMLAnchorElement, NavLinkProps>(function NavLink(
+  { onClick, href, ...rest },
+  ref,
+) {
+  const { startNavigation } = useNavigation();
+  const pathname = usePathname();
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      // Call the original onClick if provided
+      onClick?.(e);
+
+      // Don't trigger navigation loader if:
+      // - The click was prevented
+      // - It's a modifier-key click (new tab, etc.)
+      // - The href is the same as the current page
+      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+      // Resolve href to a string for comparison
+      const hrefStr = typeof href === "string" ? href : (href.pathname ?? "");
+
+      // Skip if navigating to the same page
+      if (hrefStr === pathname) return;
+
+      // Skip external links and hash-only links
+      if (hrefStr.startsWith("http") || hrefStr.startsWith("#")) return;
+
+      startNavigation();
+    },
+    [onClick, href, pathname, startNavigation],
+  );
+
+  return <Link ref={ref} href={href} onClick={handleClick} {...rest} />;
+});
+
+export { NavLink };

--- a/src/components/navigation/NavigationLoader.tsx
+++ b/src/components/navigation/NavigationLoader.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+import { useNavigation } from "@/components/navigation/NavigationContext";
+
+const SHOW_DELAY_MS = 150;
+
+export default function NavigationLoader() {
+  const { isNavigating } = useNavigation();
+  const [visible, setVisible] = useState(false);
+  const delayTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (isNavigating) {
+      // Delay showing overlay so fast navigations don't flash
+      delayTimer.current = setTimeout(() => {
+        setVisible(true);
+      }, SHOW_DELAY_MS);
+    } else {
+      if (delayTimer.current) {
+        clearTimeout(delayTimer.current);
+        delayTimer.current = null;
+      }
+      setVisible(false);
+    }
+
+    return () => {
+      if (delayTimer.current) clearTimeout(delayTimer.current);
+    };
+  }, [isNavigating]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-white/80 dark:bg-gray-950/80 backdrop-blur-sm animate-fade-in"
+      aria-live="polite"
+      aria-busy="true"
+      role="status"
+    >
+      <div className="flex flex-col items-center gap-3 animate-logo-pulse">
+        <Image
+          src="/favicon-192x192.png"
+          alt="EventTara"
+          width={48}
+          height={48}
+          className="rounded-xl"
+          priority
+        />
+        <span
+          className="text-2xl font-cursive font-bold text-lime-500"
+          style={{ WebkitTextStroke: "0.5px currentColor" }}
+        >
+          EventTara
+        </span>
+      </div>
+      <span className="sr-only">Loading page...</span>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,6 +63,14 @@ const config: Config = {
           "0%": { opacity: "0", transform: "translateY(10px)" },
           "100%": { opacity: "1", transform: "translateY(0)" },
         },
+        fadeIn: {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+        logoPulse: {
+          "0%, 100%": { opacity: "1", transform: "scale(1)" },
+          "50%": { opacity: "0.6", transform: "scale(0.95)" },
+        },
         shimmer: {
           "0%": { backgroundPosition: "-200% 0" },
           "100%": { backgroundPosition: "200% 0" },
@@ -74,6 +82,8 @@ const config: Config = {
       },
       animation: {
         "fade-up": "fadeUp 0.4s ease-out forwards",
+        "fade-in": "fadeIn 0.2s ease-out forwards",
+        "logo-pulse": "logoPulse 1.2s ease-in-out infinite",
         shimmer: "shimmer 3s linear infinite",
         "border-pulse": "borderPulse 2s ease-in-out infinite",
       },


### PR DESCRIPTION
## Summary
- Adds a branded full-screen loading overlay (favicon + "EventTara" text with pulse animation) that appears during page transitions, giving users immediate visual feedback
- Overlay shows after a 150ms delay to avoid flashing on fast navigations, with an 8s safety timeout
- Introduces `NavigationContext` with `NavLink` — a drop-in replacement for `next/link` that triggers the loading state
- Updated all primary navigation surfaces: Navbar, MobileNav, MobileDrawer, ExploreDropdown, ActivityCard, and EventCard

## Test plan
- [ ] Click nav links (desktop Navbar, mobile bottom nav, mobile drawer) — loader should appear on slow pages, not flash on fast ones
- [ ] Cmd+click / Ctrl+click should open new tab without triggering loader
- [ ] Clicking the same page link should not trigger loader
- [ ] Verify dark mode renders correctly (semi-transparent dark backdrop)
- [ ] Verify the loader auto-clears if a navigation somehow stalls (8s timeout)
- [ ] Build passes with no new lint errors or type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)