### PR TITLE
perf: optimize image delivery for parallax and event cards

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -78,7 +78,7 @@ export default function EventCard({
               src={cover_image_url}
               alt={title}
               fill
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 350px"
+              sizes="(max-width: 640px) 92vw, (max-width: 1024px) 45vw, 300px"
               className="object-cover"
             />
           )}

--- a/src/components/landing/ParallaxMountain.tsx
+++ b/src/components/landing/ParallaxMountain.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -65,11 +66,13 @@ export default function ParallaxMountain({ imageUrl, children }: ParallaxMountai
   return (
     <section ref={sectionRef} className={`relative ${hasChildren ? "h-[300vh]" : "h-[200vh]"}`}>
       <div className="sticky top-0 h-screen overflow-hidden">
-        <div
-          className="absolute inset-0 bg-center bg-cover"
-          style={{
-            backgroundImage: `url('${imageUrl}')`,
-          }}
+        <Image
+          src={imageUrl}
+          alt="Mountain landscape"
+          fill
+          sizes="100vw"
+          priority
+          className="object-cover"
         />
         <div className="absolute inset-0 bg-black/30" />
 


### PR DESCRIPTION
## Summary
- **Parallax image**: Replace CSS `background-image` with `next/image` fill mode — enables WebP/AVIF conversion, responsive sizing, and proper caching (est. ~160 KiB savings)
- **Event card images**: Tighten `sizes` prop from `100vw` to `92vw` on mobile, `50vw` to `45vw` on tablet, `350px` to `300px` on desktop — reduces oversized image downloads (est. ~50 KiB savings per card)

Addresses Lighthouse "Improve image delivery" audit (~331 KiB total savings).

## Test plan
- [ ] Parallax section still renders correctly with parallax scrolling effect
- [ ] Event card images load at appropriate sizes
- [ ] Lighthouse image delivery audit improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)