### PR TITLE
fix: add e2e/ and vercel.json to Vercel ignore command

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,5 @@
       "permanent": true
     }
   ],
-  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- src/ public/ next.config.mjs package.json pnpm-lock.yaml tailwind.config.ts tsconfig.json"
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- src/ e2e/ public/ next.config.mjs package.json pnpm-lock.yaml tailwind.config.ts tsconfig.json vercel.json"
 }


### PR DESCRIPTION
## Summary
- Add `e2e/` directory to the Vercel `ignoreCommand` watch list so E2E test changes trigger deployments
- Add `vercel.json` itself to the watch list so config changes (like this one) trigger deployments

## Test plan
- [ ] Verify Vercel builds trigger when `e2e/` files change
- [ ] Verify Vercel builds trigger when `vercel.json` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)