### PR TITLE
feat: 2-column event card grid on mobile behind feature flag

### DIFF
--- a/src/app/(frontend)/(participant)/events/page.tsx
+++ b/src/app/(frontend)/(participant)/events/page.tsx
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import EventsPageClient from "@/components/events/EventsPageClient";
 import { Breadcrumbs } from "@/components/ui";
+import { isEventsTwoColMobileEnabled } from "@/lib/cms/cached";
 import { fetchEventEnrichments, mapEventToCard } from "@/lib/events/map-event-card";
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/types";
@@ -284,10 +285,11 @@ export default async function EventsPage({
     matchingUsers = (users ?? []).filter((u): u is typeof u & { username: string } => !!u.username);
   }
 
-  // Fetch filter dropdown options in parallel
-  const [organizers, guides] = await Promise.all([
+  // Fetch filter dropdown options + feature flags in parallel
+  const [organizers, guides, twoColMobile] = await Promise.all([
     fetchOrganizerOptions(supabase),
     fetchGuideOptions(supabase),
+    isEventsTwoColMobileEnabled(),
   ]);
 
   return (
@@ -299,6 +301,7 @@ export default async function EventsPage({
         organizers={organizers}
         guides={guides}
         initialUsers={matchingUsers}
+        twoColMobile={twoColMobile}
       />
     </div>
   );

--- a/src/components/admin/FeatureFlagsForm.tsx
+++ b/src/components/admin/FeatureFlagsForm.tsx
@@ -29,6 +29,10 @@ const FLAG_META: Record<string, { label: string; description: string }> = {
     label: "Strava Showcase — Route Map",
     description: "Show the interactive route map preview on the homepage.",
   },
+  events_two_col_mobile: {
+    label: "Events — 2-Column Mobile Grid",
+    description: "Show event cards in a 2-column grid on mobile instead of single column.",
+  },
 };
 
 export default function FeatureFlagsForm() {

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -29,6 +29,7 @@ interface EventCardProps {
   difficulty_level?: number | null;
   race_distances?: number[];
   hasRoute?: boolean;
+  compact?: boolean;
 }
 
 const typeLabels: Record<string, string> = {
@@ -73,6 +74,7 @@ export default function EventCard({
   difficulty_level,
   race_distances,
   hasRoute,
+  compact,
 }: EventCardProps) {
   const spotsLeft = max_participants - booking_count;
   const formattedDate = formatEventDate(date, endDate, { short: true });
@@ -86,14 +88,23 @@ export default function EventCard({
           status === "past" && "opacity-60",
         )}
       >
-        {/* Image section (~65% of card) */}
-        <div className="relative h-52 sm:h-56 bg-gradient-to-br from-lime-100 to-forest-100 dark:from-lime-900 dark:to-forest-900">
+        {/* Image section */}
+        <div
+          className={cn(
+            "relative bg-gradient-to-br from-lime-100 to-forest-100 dark:from-lime-900 dark:to-forest-900",
+            compact ? "h-32 sm:h-56" : "h-52 sm:h-56",
+          )}
+        >
           {cover_image_url && (
             <Image
               src={cover_image_url}
               alt={title}
               fill
-              sizes="(max-width: 640px) 92vw, (max-width: 1024px) 45vw, 300px"
+              sizes={
+                compact
+                  ? "(max-width: 640px) 46vw, (max-width: 1024px) 45vw, 300px"
+                  : "(max-width: 640px) 92vw, (max-width: 1024px) 45vw, 300px"
+              }
               className="object-cover"
             />
           )}
@@ -168,11 +179,23 @@ export default function EventCard({
         </div>
 
         {/* Content section */}
-        <div className="p-3 sm:p-4 space-y-2">
+        <div className={cn("space-y-1.5", compact ? "p-2.5 sm:p-4" : "p-3 sm:p-4 space-y-2")}>
           {/* Title + Price */}
-          <div className="flex items-center justify-between gap-2">
-            <h3 className="font-heading font-bold text-base truncate">{title}</h3>
-            <span className="shrink-0 text-sm font-bold text-lime-600 dark:text-lime-400">
+          <div className="flex items-center justify-between gap-1">
+            <h3
+              className={cn(
+                "font-heading font-bold truncate",
+                compact ? "text-sm sm:text-base" : "text-base",
+              )}
+            >
+              {title}
+            </h3>
+            <span
+              className={cn(
+                "shrink-0 font-bold text-lime-600 dark:text-lime-400",
+                compact ? "text-xs sm:text-sm" : "text-sm",
+              )}
+            >
               {formattedPrice}
             </span>
           </div>
@@ -184,8 +207,49 @@ export default function EventCard({
             <p className="text-xs text-gray-400 dark:text-gray-500">by {organizer_name}</p>
           ) : null}
 
-          {/* 2-column info grid */}
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+          {/* Info — stacked when compact, 2-col grid otherwise */}
+          {compact ? (
+            <div className="space-y-1 text-xs sm:hidden">
+              <div className="flex items-center gap-1.5 text-gray-500 dark:text-gray-400 min-w-0">
+                <svg
+                  className="h-3 w-3 shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <span className="truncate">{formattedDate}</span>
+              </div>
+              <div className="flex items-center gap-1.5 text-gray-500 dark:text-gray-400 min-w-0">
+                <svg
+                  className="h-3 w-3 shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M9.69 18.933l.003.001C9.89 19.02 10 19 10 19s.11.02.308-.066l.002-.001.006-.003.018-.008a5.741 5.741 0 00.281-.14c.186-.096.446-.24.757-.433.62-.384 1.445-.966 2.274-1.765C15.302 14.988 17 12.493 17 9A7 7 0 103 9c0 3.492 1.698 5.988 3.355 7.584a13.731 13.731 0 002.273 1.765 11.842 11.842 0 00.976.544l.062.029.018.008.006.003zM10 11.25a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <span className="truncate">{location}</span>
+              </div>
+            </div>
+          ) : null}
+
+          {/* 2-column info grid (hidden on mobile when compact, always shown on sm+) */}
+          <div
+            className={cn(
+              "grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm",
+              compact && "hidden sm:grid",
+            )}
+          >
             {/* Row 1: Date | Location */}
             <div className="flex items-center gap-1.5 text-gray-500 dark:text-gray-400 min-w-0">
               <svg

--- a/src/components/events/EventsGrid.tsx
+++ b/src/components/events/EventsGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 
+import { cn } from "@/lib/utils";
 import { haversineDistance } from "@/lib/utils/geo";
 
 import EventCard from "./EventCard";
@@ -36,9 +37,10 @@ export interface NearbyState {
 interface EventsGridProps {
   events: EventData[];
   nearbyState?: NearbyState | null;
+  twoColMobile?: boolean;
 }
 
-export default function EventsGrid({ events, nearbyState }: EventsGridProps) {
+export default function EventsGrid({ events, nearbyState, twoColMobile }: EventsGridProps) {
   const eventsWithDistance = useMemo(() => {
     if (!nearbyState) {
       const distance: number | undefined = undefined;
@@ -64,7 +66,12 @@ export default function EventsGrid({ events, nearbyState }: EventsGridProps) {
   }, [events, nearbyState]);
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+    <div
+      className={cn(
+        "grid sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6",
+        twoColMobile ? "grid-cols-2" : "grid-cols-1",
+      )}
+    >
       {eventsWithDistance.map((event, i) => (
         <div
           key={event.id}
@@ -90,6 +97,7 @@ export default function EventsGrid({ events, nearbyState }: EventsGridProps) {
             difficulty_level={event.difficulty_level}
             race_distances={event.race_distances}
             hasRoute={event.hasRoute}
+            compact={twoColMobile}
           />
         </div>
       ))}

--- a/src/components/events/EventsListClient.tsx
+++ b/src/components/events/EventsListClient.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useState, useEffect, useRef, useCallback } from "react";
 
 import { SkeletonEventCard } from "@/components/ui";
+import { cn } from "@/lib/utils";
 
 import EventsGrid, { type NearbyState } from "./EventsGrid";
 
@@ -52,6 +53,7 @@ interface EventsListClientProps {
   isFiltering?: boolean;
   initialUsers?: UserResult[];
   nearbyState?: NearbyState | null;
+  twoColMobile?: boolean;
 }
 
 export default function EventsListClient({
@@ -60,6 +62,7 @@ export default function EventsListClient({
   isFiltering,
   initialUsers = [],
   nearbyState,
+  twoColMobile,
 }: EventsListClientProps) {
   const searchParams = useSearchParams();
   const [currentPage, setCurrentPage] = useState(1);
@@ -190,7 +193,12 @@ export default function EventsListClient({
 
   if (isFiltering) {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div
+        className={cn(
+          "grid sm:grid-cols-2 lg:grid-cols-3 gap-6",
+          twoColMobile ? "grid-cols-2" : "grid-cols-1",
+        )}
+      >
         {Array.from({ length: 6 }).map((_, i) => (
           <SkeletonEventCard key={i} />
         ))}
@@ -251,7 +259,7 @@ export default function EventsListClient({
         </div>
       )}
 
-      <EventsGrid events={events} nearbyState={nearbyState} />
+      <EventsGrid events={events} nearbyState={nearbyState} twoColMobile={twoColMobile} />
 
       {/* Infinite scroll sentinel */}
       {hasMore && (

--- a/src/components/events/EventsPageClient.tsx
+++ b/src/components/events/EventsPageClient.tsx
@@ -21,6 +21,7 @@ interface EventsPageClientProps {
   organizers: FilterOption[];
   guides: FilterOption[];
   initialUsers?: UserResult[];
+  twoColMobile?: boolean;
 }
 
 export default function EventsPageClient({
@@ -29,6 +30,7 @@ export default function EventsPageClient({
   organizers,
   guides,
   initialUsers = [],
+  twoColMobile,
 }: EventsPageClientProps) {
   const [isFiltering, setIsFiltering] = useState(false);
   const [nearbyState, setNearbyState] = useState<NearbyState | null>(null);
@@ -67,6 +69,7 @@ export default function EventsPageClient({
         isFiltering={isFiltering}
         initialUsers={initialUsers}
         nearbyState={nearbyState}
+        twoColMobile={twoColMobile}
       />
     </>
   );

--- a/src/lib/cms/cached.ts
+++ b/src/lib/cms/cached.ts
@@ -109,6 +109,18 @@ export async function getStravaShowcaseFlags(): Promise<{
 }
 
 /**
+ * Returns whether the events two-column mobile grid is enabled.
+ */
+export async function isEventsTwoColMobileEnabled(): Promise<boolean> {
+  try {
+    const flags = await getCachedFeatureFlags();
+    return flags?.events_two_col_mobile === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Cached hero-carousel fetch. Revalidates every 300 seconds.
  */
 export const getCachedHeroCarousel = unstable_cache(

--- a/src/lib/cms/types.ts
+++ b/src/lib/cms/types.ts
@@ -64,6 +64,7 @@ export interface CmsFeatureFlags {
   strava_showcase_features: boolean;
   strava_showcase_stats: boolean;
   strava_showcase_route_map: boolean;
+  events_two_col_mobile: boolean;
 }
 
 /** A single homepage section entry inside cms_homepage_sections.sections JSONB */

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -972,6 +972,7 @@ export interface Database {
           strava_showcase_features: boolean;
           strava_showcase_stats: boolean;
           strava_showcase_route_map: boolean;
+          events_two_col_mobile: boolean;
         };
         Insert: {
           id?: number;
@@ -979,6 +980,7 @@ export interface Database {
           strava_showcase_features?: boolean;
           strava_showcase_stats?: boolean;
           strava_showcase_route_map?: boolean;
+          events_two_col_mobile?: boolean;
         };
         Update: {
           id?: number;
@@ -986,6 +988,7 @@ export interface Database {
           strava_showcase_features?: boolean;
           strava_showcase_stats?: boolean;
           strava_showcase_route_map?: boolean;
+          events_two_col_mobile?: boolean;
         };
         Relationships: [];
       };

--- a/supabase/migrations/20260306_events_two_col_mobile_flag.sql
+++ b/supabase/migrations/20260306_events_two_col_mobile_flag.sql
@@ -1,0 +1,3 @@
+-- Add events_two_col_mobile feature flag
+ALTER TABLE cms_feature_flags
+  ADD COLUMN IF NOT EXISTS events_two_col_mobile boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- Add `events_two_col_mobile` feature flag to toggle a 2-column event card grid on mobile (default: off, single column)
- Compact card mode when flag is enabled: shorter image (h-32), smaller text, stacked date/location info
- Includes SQL migration, admin UI toggle, CMS types, and cached helper

## Test plan
- [ ] Run migration `20260306_events_two_col_mobile_flag.sql` on Supabase
- [ ] Toggle flag on in `/admin/feature-flags`
- [ ] Verify `/events` shows 2-col grid on mobile with compact cards
- [ ] Verify desktop layout (sm+) is unchanged
- [ ] Toggle flag off and verify mobile reverts to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)