### PR TITLE
chore: add staging branch workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,7 +45,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder"
 
   e2e:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     runs-on: ubuntu-latest
     needs: ci
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Branch Workflow
 
-Before making any code changes, check the current branch. If on `main`, create a new descriptive branch based on the task:
+We use a **staging branch** to batch changes before production deploys:
+
+1. **Feature branches** → PRs target **`staging`** (not `main`)
+2. CI runs on PRs to both `staging` and `main`
+3. Test on `staging` (Vercel preview deploy)
+4. When ready → merge `staging` into `main` (single production deploy)
+5. After merge, reset staging: `git checkout staging && git reset --hard main && git push --force`
+
+Before making any code changes, check the current branch. If on `main` or `staging`, create a new descriptive branch:
 
 ```bash
 git checkout -b <type>/<short-description>
 ```
 
-Use these prefixes: `feat/`, `fix/`, `refactor/`, `chore/`, `docs/`. Keep the description short and kebab-cased (e.g., `feat/explore-dropdown`, `fix/dashboard-auth-guard`). Do NOT commit directly to `main`.
+Use these prefixes: `feat/`, `fix/`, `refactor/`, `chore/`, `docs/`. Keep the description short and kebab-cased (e.g., `feat/explore-dropdown`, `fix/dashboard-auth-guard`). Do NOT commit directly to `main` or `staging`.
 
 Pre-commit hook (`husky` + `lint-staged`) automatically runs Prettier and ESLint on staged `.ts`/`.tsx` files.
 
@@ -39,7 +47,7 @@ pnpm test:e2e        # Run Playwright E2E tests (e2e/ dir, chromium only)
 
 **Package manager is strictly pnpm.** Every script runs a pre-check that exits with an error if invoked via `npm` or `yarn`.
 
-CI pipeline order: `format:check` → `lint` → `typecheck` → `test` → `build`. E2E runs only on push to main.
+CI pipeline order: `format:check` → `lint` → `typecheck` → `test` → `build`. E2E runs on push to `main` and `staging`.
 
 ## Environment Setup
 


### PR DESCRIPTION
## Summary
- Add `staging` as the PR target branch (instead of `main`) for batch testing before production deploys
- CI now triggers on pushes/PRs to both `main` and `staging`
- E2E tests run on push to both `main` and `staging`
- Updated CLAUDE.md with new branch workflow documentation

## Test plan
- [x] `staging` branch created and pushed to remote
- [x] CI YAML updated with staging triggers
- [ ] Verify CI runs on PR to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)