### PR TITLE
chore: add staging promotion guards

### DIFF
--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -1,0 +1,136 @@
+name: Promote Staging to Main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify CI passed on latest staging commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: ref } = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/staging',
+            });
+            const stagingSha = ref.object.sha;
+            core.info(`Latest staging commit: ${stagingSha.substring(0, 7)}`);
+
+            // Check that CI workflow succeeded on the latest staging commit
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              branch: 'staging',
+              head_sha: stagingSha,
+              status: 'success',
+              per_page: 1,
+            });
+
+            if (runs.total_count === 0) {
+              // Check if CI is still running
+              const { data: inProgress } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci.yml',
+                branch: 'staging',
+                head_sha: stagingSha,
+                status: 'in_progress',
+                per_page: 1,
+              });
+
+              if (inProgress.total_count > 0) {
+                core.setFailed('CI is still running on staging. Wait for it to finish before promoting.');
+              } else {
+                core.setFailed('CI has not passed on the latest staging commit. Fix failures before promoting.');
+              }
+              return;
+            }
+
+            core.info('CI passed on staging');
+
+      - name: Verify Vercel deployment succeeded
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: ref } = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/staging',
+            });
+            const stagingSha = ref.object.sha;
+
+            // Check deployment statuses (Vercel sets these)
+            const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: stagingSha,
+            });
+
+            const vercelStatuses = combined.statuses.filter(
+              s => s.context.toLowerCase().includes('vercel')
+            );
+
+            // Also check check runs (Vercel may use checks API instead)
+            const { data: checks } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: stagingSha,
+            });
+
+            const vercelChecks = checks.check_runs.filter(
+              c => (c.app && c.app.slug === 'vercel') || c.name.toLowerCase().includes('vercel')
+            );
+
+            if (vercelStatuses.length === 0 && vercelChecks.length === 0) {
+              core.warning('No Vercel deployment found for staging — skipping deployment check');
+              return;
+            }
+
+            // Check commit statuses
+            for (const status of vercelStatuses) {
+              if (status.state === 'pending') {
+                core.setFailed(`Vercel deployment is still in progress: "${status.context}"`);
+                return;
+              }
+              if (status.state !== 'success') {
+                core.setFailed(`Vercel deployment failed: "${status.context}" — ${status.description || status.state}`);
+                return;
+              }
+            }
+
+            // Check check runs
+            for (const check of vercelChecks) {
+              if (check.status !== 'completed') {
+                core.setFailed(`Vercel deployment is still in progress: "${check.name}"`);
+                return;
+              }
+              if (check.conclusion !== 'success') {
+                core.setFailed(`Vercel deployment failed: "${check.name}" — ${check.conclusion}`);
+                return;
+              }
+            }
+
+            core.info('Vercel deployment passed on staging');
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Merge staging into main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout main
+          git merge origin/staging --ff-only
+          git push origin main
+
+      - name: Reset staging to main
+        run: |
+          git checkout staging
+          git reset --hard main
+          git push --force origin staging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,7 @@ We use a **staging branch** to batch changes before production deploys:
 1. **Feature branches** → PRs target **`staging`** (not `main`)
 2. CI runs on PRs to both `staging` and `main`
 3. Test on `staging` (Vercel preview deploy)
-4. When ready → merge `staging` into `main` (single production deploy)
-5. After merge, reset staging: `git checkout staging && git reset --hard main && git push --force`
+4. When ready → run the **"Promote Staging to Main"** workflow (Actions tab → manual trigger). It verifies CI + Vercel deployment passed on staging before merging to `main` and resetting staging.
 
 Before making any code changes, check the current branch. If on `main` or `staging`, create a new descriptive branch:
 


### PR DESCRIPTION
## Summary
- Add `promote-staging.yml` workflow — manually triggered guard for staging → main merges
- Verifies CI passed on the latest staging commit before promoting
- Verifies Vercel deployment succeeded (or warns if no deployment found)
- Merges with `--ff-only` for clean history, then auto-resets staging
- Update CLAUDE.md to document the promotion workflow

## Test plan
- [ ] Trigger "Promote Staging to Main" from Actions tab — should fail gracefully if CI hasn't run
- [ ] After CI passes on staging, trigger again — should succeed and merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)