### PR TITLE
fix: add write permission for staging PR auto-update

### DIFF
--- a/.github/workflows/update-staging-pr.yml
+++ b/.github/workflows/update-staging-pr.yml
@@ -5,6 +5,9 @@ on:
     branches: [staging]
     types: [closed]
 
+permissions:
+  pull-requests: write
+
 jobs:
   update-description:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to `update-staging-pr.yml`
- The default `GITHUB_TOKEN` was returning 403 when trying to update the staging → main PR description

## Test plan
- [ ] Merge this PR — the workflow should auto-update PR #140 with this entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)