### PR TITLE
feat: pioneer badges, first review badge, and homepage counter

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -2843,14 +2843,41 @@ const SYSTEM_BADGE_DEFS: SystemBadgeDef[] = [
     rarity: "legendary",
     imageUrl: "\u{1F451}",
   },
-  // Pioneer
+  // Pioneer (check-in)
   {
     criteriaKey: "pioneer",
-    title: "EventTara Pioneer",
+    title: "Check-in Pioneer",
     description: "Among the first 100 users to check in on EventTara",
     category: "special",
     rarity: "legendary",
     imageUrl: "\u{1F680}",
+  },
+  // Pioneer (signup)
+  {
+    criteriaKey: "pioneer_participant",
+    title: "Pioneer Participant",
+    description: "Among the first 250 users to join EventTara",
+    category: "special",
+    rarity: "legendary",
+    imageUrl: "\u{1F31F}",
+  },
+  // Pioneer (organizer)
+  {
+    criteriaKey: "pioneer_organizer",
+    title: "Pioneer Organizer",
+    description: "Among the first 50 organizers on EventTara",
+    category: "special",
+    rarity: "legendary",
+    imageUrl: "\u{1F3D4}\uFE0F",
+  },
+  // First review
+  {
+    criteriaKey: "first_review",
+    title: "First Review",
+    description: "Wrote your first organizer review on EventTara",
+    category: "special",
+    rarity: "rare",
+    imageUrl: "\u270D\uFE0F",
   },
 ];
 

--- a/src/app/(frontend)/api/cron/award-pioneer-badges/route.ts
+++ b/src/app/(frontend)/api/cron/award-pioneer-badges/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+import { checkAndAwardPioneerBadges } from "@/lib/badges/check-pioneer-badges";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export async function POST(request: Request) {
+  const cronSecret = request.headers.get("x-cron-secret");
+  if (!cronSecret || cronSecret !== process.env.CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createServiceClient();
+
+  const result = await checkAndAwardPioneerBadges(supabase);
+
+  return NextResponse.json(result);
+}

--- a/src/app/(frontend)/api/organizers/[id]/reviews/route.ts
+++ b/src/app/(frontend)/api/organizers/[id]/reviews/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { awardFirstReviewBadge } from "@/lib/badges/check-pioneer-badges";
 import {
   MAX_REVIEW_PHOTOS,
   MAX_REVIEW_TEXT_LENGTH,
@@ -229,6 +230,10 @@ export async function POST(request: Request, { params }: RouteCtx) {
     }));
     await supabase.from("organizer_review_photos").insert(photoRows);
   }
+
+  // Fire-and-forget: award "First Review" badge if this is the user's first review
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  awardFirstReviewBadge(user.id, supabase).catch(() => {});
 
   return NextResponse.json({ review }, { status: 201 });
 }

--- a/src/app/(frontend)/api/stats/pioneers/route.ts
+++ b/src/app/(frontend)/api/stats/pioneers/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { createServiceClient } from "@/lib/supabase/server";
+
+const PARTICIPANT_CAP = 250;
+const ORGANIZER_CAP = 50;
+
+export async function GET() {
+  const supabase = createServiceClient();
+
+  const [usersResult, organizersResult] = await Promise.all([
+    supabase.from("users").select("id", { count: "exact", head: true }).neq("role", "guest"),
+    supabase.from("organizer_profiles").select("id", { count: "exact", head: true }),
+  ]);
+
+  const participants = Math.min(usersResult.count ?? 0, PARTICIPANT_CAP);
+  const organizers = Math.min(organizersResult.count ?? 0, ORGANIZER_CAP);
+
+  return NextResponse.json(
+    { participants, organizers, participantCap: PARTICIPANT_CAP, organizerCap: ORGANIZER_CAP },
+    { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60" } },
+  );
+}

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -12,6 +12,7 @@ import HowItWorksSection from "@/components/landing/HowItWorksSection";
 import OrganizersSection from "@/components/landing/OrganizersSection";
 import OrganizerWaitlistModal from "@/components/landing/OrganizerWaitlistModal";
 import ParallaxMountain from "@/components/landing/ParallaxMountain";
+import PioneerCounterSection from "@/components/landing/PioneerCounterSection";
 import StravaShowcaseSection from "@/components/landing/StravaShowcaseSection";
 import TestimonialsSection from "@/components/landing/TestimonialsSection";
 import {
@@ -46,9 +47,10 @@ const DEFAULT_SECTIONS: CmsHomepageSection[] = [
   { key: "gamification", label: "Badges & Gamification", enabled: true, order: 5 },
   { key: "categories", label: "Event Categories", enabled: true, order: 6 },
   { key: "organizers", label: "Trusted Organizers", enabled: true, order: 7 },
-  { key: "testimonials", label: "Testimonials", enabled: true, order: 8 },
-  { key: "faq", label: "FAQ", enabled: true, order: 9 },
-  { key: "contact_cta", label: "Contact CTA", enabled: true, order: 10 },
+  { key: "pioneer_counter", label: "Pioneer Counter", enabled: true, order: 8 },
+  { key: "testimonials", label: "Testimonials", enabled: true, order: 9 },
+  { key: "faq", label: "FAQ", enabled: true, order: 10 },
+  { key: "contact_cta", label: "Contact CTA", enabled: true, order: 11 },
 ];
 
 function BentoEventsSkeleton() {
@@ -215,6 +217,9 @@ function renderSection(key: string, parallaxImageUrl: string, heroData: HeroData
           <OrganizersSection />
         </Suspense>
       );
+    }
+    case "pioneer_counter": {
+      return <PioneerCounterSection />;
     }
     case "testimonials": {
       return (

--- a/src/components/landing/PioneerCounterSection.tsx
+++ b/src/components/landing/PioneerCounterSection.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface PioneerStats {
+  participants: number;
+  organizers: number;
+  participantCap: number;
+  organizerCap: number;
+}
+
+function useCountUp(target: number, duration = 1500) {
+  const [value, setValue] = useState(0);
+  const started = useRef(false);
+
+  const start = useCallback(() => {
+    if (started.current || target === 0) return;
+    started.current = true;
+
+    const startTime = performance.now();
+    function tick(now: number) {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setValue(Math.round(eased * target));
+      if (progress < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  }, [target, duration]);
+
+  return { value, start };
+}
+
+function CounterCard({
+  label,
+  count,
+  cap,
+  emoji,
+  onVisible,
+}: {
+  label: string;
+  count: number;
+  cap: number;
+  emoji: string;
+  onVisible: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const observerFired = useRef(false);
+  const percentage = cap > 0 ? Math.min((count / cap) * 100, 100) : 0;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || observerFired.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !observerFired.current) {
+          observerFired.current = true;
+          onVisible();
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.3 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onVisible]);
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col items-center rounded-2xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+    >
+      <span className="mb-2 text-3xl">{emoji}</span>
+      <span className="text-3xl font-bold tabular-nums text-teal-700 dark:text-teal-400 sm:text-4xl">
+        {count}
+      </span>
+      <span className="mt-1 text-xs font-medium text-gray-500 dark:text-gray-400">
+        of {cap} {label}
+      </span>
+      <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-teal-500 to-teal-600 transition-all duration-1000 ease-out"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function PioneerCounterSection() {
+  const [stats, setStats] = useState<PioneerStats | null>(null);
+
+  const participantCounter = useCountUp(stats?.participants ?? 0);
+  const organizerCounter = useCountUp(stats?.organizers ?? 0);
+
+  useEffect(() => {
+    fetch("/api/stats/pioneers")
+      .then((r) => r.json())
+      .then((data: PioneerStats) => setStats(data))
+      .catch(console.error);
+  }, []);
+
+  if (!stats) return null;
+
+  return (
+    <section className="bg-gray-50 py-12 dark:bg-slate-900">
+      <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
+        <h2 className="mb-2 text-2xl font-bold text-gray-900 dark:text-white sm:text-3xl">
+          Join the Pioneers
+        </h2>
+        <p className="mb-8 text-sm text-gray-500 dark:text-gray-400">
+          Exclusive badges for our earliest community members
+        </p>
+        <div className="grid grid-cols-2 gap-4">
+          <CounterCard
+            label="Participants"
+            count={participantCounter.value}
+            cap={stats.participantCap}
+            emoji="🌟"
+            onVisible={participantCounter.start}
+          />
+          <CounterCard
+            label="Organizers"
+            count={organizerCounter.value}
+            cap={stats.organizerCap}
+            emoji="🏔️"
+            onVisible={organizerCounter.start}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/badges/check-pioneer-badges.ts
+++ b/src/lib/badges/check-pioneer-badges.ts
@@ -1,0 +1,155 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { createNotifications } from "@/lib/notifications/create";
+import type { Database } from "@/lib/supabase/types";
+
+const PIONEER_PARTICIPANT_CAP = 250;
+const PIONEER_ORGANIZER_CAP = 50;
+
+/**
+ * Batch-evaluate and award pioneer badges + first review badges.
+ * Called by the cron endpoint every 6 hours.
+ */
+export async function checkAndAwardPioneerBadges(
+  supabase: SupabaseClient<Database>,
+): Promise<{ participantsAwarded: number; organizersAwarded: number; reviewsAwarded: number }> {
+  const result = { participantsAwarded: 0, organizersAwarded: 0, reviewsAwarded: 0 };
+
+  // --- Pioneer Participant: first 250 non-guest users by created_at ---
+  result.participantsAwarded = await awardBadgeForSet(supabase, "pioneer_participant", async () => {
+    const { data } = await supabase
+      .from("users")
+      .select("id")
+      .neq("role", "guest")
+      .order("created_at", { ascending: true })
+      .limit(PIONEER_PARTICIPANT_CAP);
+    return (data ?? []).map((u) => u.id);
+  });
+
+  // --- Pioneer Organizer: first 50 organizer profiles by created_at ---
+  result.organizersAwarded = await awardBadgeForSet(supabase, "pioneer_organizer", async () => {
+    const { data } = await supabase
+      .from("organizer_profiles")
+      .select("user_id")
+      .order("created_at", { ascending: true })
+      .limit(PIONEER_ORGANIZER_CAP);
+    return (data ?? []).map((o) => o.user_id);
+  });
+
+  // --- First Review: distinct users who have at least one organizer review ---
+  result.reviewsAwarded = await awardBadgeForSet(supabase, "first_review", async () => {
+    const { data } = await supabase.from("organizer_reviews").select("user_id");
+    const unique = [...new Set((data ?? []).map((r) => r.user_id))];
+    return unique;
+  });
+
+  return result;
+}
+
+/**
+ * Generic helper: find badge by criteria_key, find eligible users missing it, bulk award.
+ */
+async function awardBadgeForSet(
+  supabase: SupabaseClient<Database>,
+  criteriaKey: string,
+  getEligibleUserIds: () => Promise<string[]>,
+): Promise<number> {
+  // Look up the badge row
+  const { data: badge } = await supabase
+    .from("badges")
+    .select("id, title")
+    .eq("criteria_key", criteriaKey)
+    .eq("type", "system")
+    .single();
+
+  if (!badge) return 0;
+
+  const eligibleUserIds = await getEligibleUserIds();
+  if (eligibleUserIds.length === 0) return 0;
+
+  // Find which users already have this badge
+  const { data: existing } = await supabase
+    .from("user_badges")
+    .select("user_id")
+    .eq("badge_id", badge.id)
+    .in("user_id", eligibleUserIds);
+
+  const alreadyAwarded = new Set((existing ?? []).map((r) => r.user_id));
+  const toAward = eligibleUserIds.filter((id) => !alreadyAwarded.has(id));
+  if (toAward.length === 0) return 0;
+
+  // Bulk insert user_badges
+  const rows = toAward.map((userId) => ({ user_id: userId, badge_id: badge.id }));
+  const { error } = await supabase.from("user_badges").insert(rows);
+
+  if (error) {
+    console.error(`[pioneer-badges] Failed to award ${criteriaKey}:`, error.message);
+    return 0;
+  }
+
+  // Create notifications
+  await createNotifications(
+    supabase,
+    toAward.map((userId) => ({
+      userId,
+      type: "badge_earned" as const,
+      title: "Badge Earned!",
+      body: `You earned the "${badge.title}" badge`,
+      href: "/my-events?tab=badges",
+    })),
+  );
+
+  return toAward.length;
+}
+
+/**
+ * Eagerly award the "first_review" badge to a single user right after they write a review.
+ * Fire-and-forget — errors are logged but do not propagate.
+ */
+export async function awardFirstReviewBadge(
+  userId: string,
+  supabase: SupabaseClient<Database>,
+): Promise<void> {
+  try {
+    const { data: badge } = await supabase
+      .from("badges")
+      .select("id, title")
+      .eq("criteria_key", "first_review")
+      .eq("type", "system")
+      .single();
+
+    if (!badge) return;
+
+    // Check if already awarded
+    const { data: existing } = await supabase
+      .from("user_badges")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("badge_id", badge.id)
+      .single();
+
+    if (existing) return;
+
+    const { error } = await supabase.from("user_badges").insert({
+      user_id: userId,
+      badge_id: badge.id,
+    });
+
+    if (error) {
+      console.error(`[first-review-badge] Failed to award to ${userId}:`, error.message);
+      return;
+    }
+
+    await createNotifications(supabase, [
+      {
+        userId,
+        type: "badge_earned" as const,
+        title: "Badge Earned!",
+        body: `You earned the "${badge.title}" badge`,
+        href: "/my-events?tab=badges",
+      },
+    ]);
+  } catch (error) {
+    console.error("[first-review-badge] Unexpected error:", error);
+  }
+}

--- a/src/lib/constants/system-badges.ts
+++ b/src/lib/constants/system-badges.ts
@@ -10,9 +10,9 @@ export interface SystemBadge {
 }
 
 /**
- * All 16 system badges that are automatically awarded on check-in.
+ * All 19 system badges that are automatically awarded.
  * These are seeded into the `badges` table with `type = 'system'`
- * and evaluated by the badge engine after every check-in.
+ * and evaluated by the badge engine after check-in, signup, or review.
  */
 export const SYSTEM_BADGES: SystemBadge[] = [
   // First activity per type
@@ -148,14 +148,41 @@ export const SYSTEM_BADGES: SystemBadge[] = [
     rarity: "rare",
     imageUrl: "🔗",
   },
-  // Pioneer
+  // Pioneer (check-in)
   {
     criteriaKey: "pioneer",
-    title: "EventTara Pioneer",
+    title: "Check-in Pioneer",
     description: "Among the first 100 users to check in on EventTara",
     category: "special",
     rarity: "legendary",
     imageUrl: "🚀",
+  },
+  // Pioneer (signup)
+  {
+    criteriaKey: "pioneer_participant",
+    title: "Pioneer Participant",
+    description: "Among the first 250 users to join EventTara",
+    category: "special",
+    rarity: "legendary",
+    imageUrl: "🌟",
+  },
+  // Pioneer (organizer)
+  {
+    criteriaKey: "pioneer_organizer",
+    title: "Pioneer Organizer",
+    description: "Among the first 50 organizers on EventTara",
+    category: "special",
+    rarity: "legendary",
+    imageUrl: "🏔️",
+  },
+  // First review
+  {
+    criteriaKey: "first_review",
+    title: "First Review",
+    description: "Wrote your first organizer review on EventTara",
+    category: "special",
+    rarity: "rare",
+    imageUrl: "✍️",
   },
 ];
 
@@ -184,4 +211,7 @@ export const SYSTEM_BADGE_CRITERIA_HINTS: Record<string, string> = {
   distance_100k: "Complete a 100km+ ultra event",
   strava_connected: "Connect your Strava account",
   pioneer: "Be among the first 100 users to check in on EventTara",
+  pioneer_participant: "Be among the first 250 users to join EventTara",
+  pioneer_organizer: "Be among the first 50 organizers on EventTara",
+  first_review: "Write your first organizer review",
 };

--- a/supabase/migrations/20260306_pioneer_badges.sql
+++ b/supabase/migrations/20260306_pioneer_badges.sql
@@ -1,0 +1,60 @@
+-- Pioneer badges: rename existing check-in pioneer, add new pioneer + first_review badges
+-- Also schedules a cron job to award pioneer badges every 6 hours
+
+-- 1. Rename existing check-in pioneer badge
+UPDATE badges
+SET title       = 'Check-in Pioneer',
+    description = 'Among the first 100 users to check in on EventTara'
+WHERE criteria_key = 'pioneer'
+  AND type = 'system';
+
+-- 2. Insert new system badges (idempotent with ON CONFLICT)
+INSERT INTO badges (title, description, image_url, category, rarity, type, criteria_key)
+VALUES
+  ('Pioneer Participant', 'Among the first 250 users to join EventTara', '🌟', 'special', 'legendary', 'system', 'pioneer_participant'),
+  ('Pioneer Organizer', 'Among the first 50 organizers on EventTara', '🏔️', 'special', 'legendary', 'system', 'pioneer_organizer'),
+  ('First Review', 'Wrote your first organizer review on EventTara', '✍️', 'special', 'rare', 'system', 'first_review')
+ON CONFLICT (criteria_key) WHERE criteria_key IS NOT NULL DO NOTHING;
+
+-- 3. pg_cron function to call the award endpoint
+CREATE OR REPLACE FUNCTION award_pioneer_badges_via_http()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  _cron_secret text;
+  _site_url    text;
+BEGIN
+  -- Read secrets from vault (or fall back to current_setting)
+  SELECT decrypted_secret INTO _cron_secret
+  FROM vault.decrypted_secrets
+  WHERE name = 'cron_secret'
+  LIMIT 1;
+
+  SELECT decrypted_secret INTO _site_url
+  FROM vault.decrypted_secrets
+  WHERE name = 'site_url'
+  LIMIT 1;
+
+  IF _cron_secret IS NULL OR _site_url IS NULL THEN
+    RAISE WARNING 'award_pioneer_badges_via_http: missing vault secrets (cron_secret or site_url)';
+    RETURN;
+  END IF;
+
+  PERFORM net.http_post(
+    url     := _site_url || '/api/cron/award-pioneer-badges',
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'x-cron-secret', _cron_secret
+    ),
+    body    := '{}'::jsonb
+  );
+END;
+$$;
+
+-- 4. Schedule: every 6 hours at minute 45
+SELECT cron.schedule(
+  'award-pioneer-badges',
+  '45 */6 * * *',
+  $$ SELECT award_pioneer_badges_via_http(); $$
+);


### PR DESCRIPTION
## Summary
- Add 3 new system badges: **Pioneer Participant** (first 250 signups), **Pioneer Organizer** (first 50 organizers), **First Review** (first organizer review)
- Rename existing pioneer badge to **Check-in Pioneer** to avoid confusion
- Add animated **Pioneer Counter** section on homepage with progress bars showing spots remaining
- Cron job (`/api/cron/award-pioneer-badges`) runs every 6 hours to batch-award pioneer badges
- First Review badge is awarded eagerly on review creation (fire-and-forget)
- New `/api/stats/pioneers` endpoint for counter data (5-min cache)

## Test plan
- [ ] Run SQL migration `20260306_pioneer_badges.sql` in Supabase
- [ ] Verify 3 new badges appear in `badges` table
- [ ] Verify existing pioneer badge title is now "Check-in Pioneer"
- [ ] Homepage shows animated pioneer counter section after organizers
- [ ] POST to `/api/cron/award-pioneer-badges` with valid cron secret awards qualifying users
- [ ] Writing a first organizer review triggers First Review badge notification
- [ ] Verify vault secrets (`cron_secret`, `site_url`) are set for pg_cron to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)