### PR TITLE
fix: filter null user_id in pioneer badge check

### DIFF
--- a/src/lib/badges/check-pioneer-badges.ts
+++ b/src/lib/badges/check-pioneer-badges.ts
@@ -33,7 +33,7 @@ export async function checkAndAwardPioneerBadges(
       .select("user_id")
       .order("created_at", { ascending: true })
       .limit(PIONEER_ORGANIZER_CAP);
-    return (data ?? []).map((o) => o.user_id);
+    return (data ?? []).map((o) => o.user_id).filter((id): id is string => id !== null);
   });
 
   // --- First Review: distinct users who have at least one organizer review ---


### PR DESCRIPTION
## Summary
- Fix build failure: `organizer_profiles.user_id` is `string | null`, filter out nulls before passing to badge award function

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)