### PR TITLE
style: replace hero subheading with activity focus tagline

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -68,9 +68,9 @@ export default function HeroSection({ heroData }: HeroSectionProps) {
           Tara na!
         </h1>
         <p
-          className={`text-lg sm:text-xl mb-6 font-medium ${heroSlides.length > 0 ? "text-lime-300" : "text-lime-600 dark:text-lime-400"}`}
+          className={`text-lg sm:text-xl mb-6 font-medium tracking-wide ${heroSlides.length > 0 ? "text-lime-300" : "text-lime-600 dark:text-lime-400"}`}
         >
-          Built by a hiker in Iloilo for adventurers across the Philippines
+          Hiking · Biking · Running · Trail Running
         </p>
         <p
           className={`text-xl sm:text-2xl mb-10 max-w-2xl mx-auto ${heroSlides.length > 0 ? "text-gray-200" : "text-gray-600 dark:text-gray-400"}`}


### PR DESCRIPTION
## Summary
- Replace "Built by a hiker in Iloilo for adventurers across the Philippines" with "Hiking · Biking · Running · Trail Running" in the hero section

## Test plan
- [ ] Visit homepage → verify hero shows "Hiking · Biking · Running · Trail Running" below "Tara na!"
- [ ] Check with and without hero carousel slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)