### PR TITLE
fix: organizer claim flow for existing users

### DIFF
--- a/src/app/(frontend)/api/claim/[token]/route.ts
+++ b/src/app/(frontend)/api/claim/[token]/route.ts
@@ -1,30 +1,29 @@
 import { NextResponse } from "next/server";
 
-import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/server";
 
 export async function POST(request: Request, { params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;
-  const supabase = await createClient();
 
   // Parse and validate body
   const body = await request.json();
-  const { email, password, full_name, org_name } = body as {
-    email: string;
-    password: string;
-    full_name: string;
+  const { email, password, full_name, org_name, existing_user_id } = body as {
+    email?: string;
+    password?: string;
+    full_name?: string;
     org_name: string;
+    existing_user_id?: string;
   };
 
-  if (!email || !password || !full_name || !org_name) {
-    return NextResponse.json({ error: "All fields are required" }, { status: 400 });
+  if (!org_name) {
+    return NextResponse.json({ error: "Organization name is required" }, { status: 400 });
   }
 
-  if (password.length < 6) {
-    return NextResponse.json({ error: "Password must be at least 6 characters" }, { status: 400 });
-  }
+  // Use service client for all operations
+  const adminClient = createServiceClient();
 
   // Look up the organizer profile by claim token
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile, error: profileError } = await adminClient
     .from("organizer_profiles")
     .select("id, claim_expires_at, is_claimed, pending_username")
     .eq("claim_token", token)
@@ -45,49 +44,76 @@ export async function POST(request: Request, { params }: { params: Promise<{ tok
     );
   }
 
-  // Sign up the user
-  const { data: authData, error: authError } = await supabase.auth.signUp({
-    email,
-    password,
-    options: {
-      data: {
+  let userId: string;
+
+  if (existing_user_id) {
+    // Signed-in user claiming — just upgrade their role, don't overwrite details
+    userId = existing_user_id;
+
+    const { error: userError } = await adminClient
+      .from("users")
+      .update({ role: "organizer" as const })
+      .eq("id", userId);
+
+    if (userError) {
+      return NextResponse.json({ error: "Failed to update user role" }, { status: 500 });
+    }
+  } else {
+    // New user claiming — validate required fields
+    if (!email || !password || !full_name) {
+      return NextResponse.json({ error: "All fields are required" }, { status: 400 });
+    }
+
+    if (password.length < 6) {
+      return NextResponse.json(
+        { error: "Password must be at least 6 characters" },
+        { status: 400 },
+      );
+    }
+
+    // Create user with auto-confirm so they can sign in immediately
+    const { data: authData, error: authError } = await adminClient.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: {
         full_name,
         role: "organizer",
       },
-    },
-  });
+    });
 
-  if (authError) {
-    if (authError.message?.includes("already registered")) {
-      return NextResponse.json(
-        { error: "This email is already registered. Please use a different email or log in." },
-        { status: 409 },
-      );
+    if (authError) {
+      if (authError.message?.includes("already registered")) {
+        return NextResponse.json(
+          { error: "This email is already registered. Please use a different email or log in." },
+          { status: 409 },
+        );
+      }
+      return NextResponse.json({ error: authError.message }, { status: 400 });
     }
-    return NextResponse.json({ error: authError.message }, { status: 400 });
-  }
 
-  const userId = authData.user?.id;
-  if (!userId) {
-    return NextResponse.json({ error: "Failed to create account" }, { status: 500 });
-  }
+    userId = authData.user?.id ?? "";
+    if (!userId) {
+      return NextResponse.json({ error: "Failed to create account" }, { status: 500 });
+    }
 
-  // Update the users table
-  const { error: userError } = await supabase
-    .from("users")
-    .update({
-      full_name,
-      role: "organizer" as const,
-      username: profile.pending_username,
-    })
-    .eq("id", userId);
+    // Update the users table with claim details
+    const { error: userError } = await adminClient
+      .from("users")
+      .update({
+        full_name,
+        role: "organizer" as const,
+        username: profile.pending_username,
+      })
+      .eq("id", userId);
 
-  if (userError) {
-    return NextResponse.json({ error: "Failed to update user profile" }, { status: 500 });
+    if (userError) {
+      return NextResponse.json({ error: "Failed to update user profile" }, { status: 500 });
+    }
   }
 
   // Update the organizer profile
-  const { error: orgError } = await supabase
+  const { error: orgError } = await adminClient
     .from("organizer_profiles")
     .update({
       user_id: userId,
@@ -103,5 +129,5 @@ export async function POST(request: Request, { params }: { params: Promise<{ tok
     return NextResponse.json({ error: "Failed to update organizer profile" }, { status: 500 });
   }
 
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true, isExistingUser: !!existing_user_id });
 }

--- a/src/app/(frontend)/claim/[token]/ClaimForm.tsx
+++ b/src/app/(frontend)/claim/[token]/ClaimForm.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 
 import { Button, Input } from "@/components/ui";
 import { createClient } from "@/lib/supabase/client";
@@ -23,6 +23,24 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [existingUserId, setExistingUserId] = useState<string | null>(null);
+  const [existingUserName, setExistingUserName] = useState<string | null>(null);
+  const [checkingAuth, setCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    async function checkAuth() {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user) {
+        setExistingUserId(user.id);
+        setExistingUserName(user.user_metadata?.full_name ?? user.email ?? "your account");
+      }
+      setCheckingAuth(false);
+    }
+    void checkAuth();
+  }, []);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -30,15 +48,14 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
     setLoading(true);
 
     try {
+      const payload = existingUserId
+        ? { org_name: editedOrgName, existing_user_id: existingUserId }
+        : { email, password, full_name: fullName, org_name: editedOrgName };
+
       const res = await fetch(`/api/claim/${token}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          email,
-          password,
-          full_name: fullName,
-          org_name: editedOrgName,
-        }),
+        body: JSON.stringify(payload),
       });
 
       const data = await res.json();
@@ -49,16 +66,19 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
         return;
       }
 
-      const supabase = createClient();
-      const { error: signInError } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
+      // If new user, sign them in
+      if (!existingUserId) {
+        const supabase = createClient();
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
 
-      if (signInError) {
-        setError("Account created but login failed. Please go to the login page.");
-        setLoading(false);
-        return;
+        if (signInError) {
+          setError("Account created but login failed. Please go to the login page.");
+          setLoading(false);
+          return;
+        }
       }
 
       setSuccess(true);
@@ -92,6 +112,14 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
     );
   }
 
+  if (checkingAuth) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-lime-500 border-t-transparent" />
+      </div>
+    );
+  }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <div className="text-center space-y-3">
@@ -113,6 +141,12 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
         <h1 className="text-xl font-bold text-gray-900 dark:text-white">
           Claim Your Organizer Account
         </h1>
+        {existingUserId && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Signed in as{" "}
+            <span className="font-medium text-gray-700 dark:text-gray-300">{existingUserName}</span>
+          </p>
+        )}
       </div>
 
       <div className="space-y-4">
@@ -124,7 +158,7 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
           required
         />
 
-        {pendingUsername && (
+        {!existingUserId && pendingUsername && (
           <div className="space-y-1">
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
               Username
@@ -135,34 +169,38 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
           </div>
         )}
 
-        <Input
-          id="full-name"
-          label="Full Name"
-          value={fullName}
-          onChange={(e) => setFullName(e.target.value)}
-          placeholder="Your full name"
-          required
-        />
+        {!existingUserId && (
+          <>
+            <Input
+              id="full-name"
+              label="Full Name"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              placeholder="Your full name"
+              required
+            />
 
-        <Input
-          id="email"
-          label="Email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="you@example.com"
-          required
-        />
+            <Input
+              id="email"
+              label="Email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+            />
 
-        <Input
-          id="password"
-          label="Password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="Min. 6 characters"
-          required
-        />
+            <Input
+              id="password"
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Min. 6 characters"
+              required
+            />
+          </>
+        )}
       </div>
 
       {error && (
@@ -172,7 +210,7 @@ export default function ClaimForm({ token, orgName, logoUrl, pendingUsername }: 
       )}
 
       <Button type="submit" disabled={loading} className="w-full">
-        {loading ? "Claiming..." : "Claim Account"}
+        {loading ? "Claiming..." : existingUserId ? "Link to My Account" : "Claim Account"}
       </Button>
     </form>
   );


### PR DESCRIPTION
## Summary
- If a signed-in user opens a claim link, their existing account is upgraded to organizer without overwriting their name/username
- New users are auto-confirmed via `admin.createUser` so they can sign in immediately (fixes "login failed" error)
- All operations use service role client to bypass RLS
- ClaimForm detects auth state and shows simplified "Link to My Account" UI for signed-in users

## Test plan
- [ ] New user claims organizer → account created, auto-signed in, redirected to dashboard
- [ ] Signed-in user claims organizer → role upgraded, existing details preserved, redirected to dashboard
- [ ] Already-claimed token → shows error
- [ ] Expired token → shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)