### PR TITLE
fix: Google OAuth missing users row + profile images

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,6 +40,11 @@ const nextConfig = {
         protocol: "https",
         hostname: "images.unsplash.com",
       },
+      // Google user profile photos
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
       // Strava CDN (athlete profile photos)
       {
         protocol: "https",

--- a/src/app/(frontend)/auth/callback/route.ts
+++ b/src/app/(frontend)/auth/callback/route.ts
@@ -19,6 +19,24 @@ export async function GET(request: Request) {
       if (user) {
         const provider = user.app_metadata?.provider;
 
+        // Ensure public.users row exists (trigger may not have fired yet for OAuth)
+        const { data: existingRow } = await supabase
+          .from("users")
+          .select("id")
+          .eq("id", user.id)
+          .single();
+
+        if (!existingRow) {
+          const meta = user.user_metadata;
+          await supabase.from("users").insert({
+            id: user.id,
+            email: user.email ?? null,
+            full_name: meta?.full_name ?? meta?.name ?? "User",
+            avatar_url: meta?.avatar_url ?? meta?.picture ?? null,
+            role: "participant",
+          });
+        }
+
         // Sync Google profile data to users table
         if (provider === "google") {
           const meta = user.user_metadata;


### PR DESCRIPTION
## Summary
- Ensure `public.users` row exists before syncing Google profile data — the DB trigger may not fire for OAuth signups, causing `generateUsername` and profile updates to silently affect 0 rows
- Add `lh3.googleusercontent.com` to `next/image` remote patterns for Google profile photos

## Test plan
- [ ] Sign out, sign back in with Google → verify username is generated and `/profile` works
- [ ] Verify Google profile photo renders without next/image error

🤖 Generated with [Claude Code](https://claude.com/claude-code)