### PR TITLE
feat: E2E authenticated booking flow + fix existing specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ test-results/
 playwright-report/
 blob-report/
 .playwright/
+e2e/.auth/
 
 # next.js
 /.next/

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,34 @@
+import { type Page, test as setup, expect } from "@playwright/test";
+
+const ORGANIZER = {
+  email: "organizer1@test.eventtara.com",
+  password: "TestPass123!",
+  storageState: "e2e/.auth/organizer.json",
+};
+
+const PARTICIPANT = {
+  email: "participant1@test.eventtara.com",
+  password: "TestPass123!",
+  storageState: "e2e/.auth/participant.json",
+};
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto("/login");
+
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.locator("form").getByRole("button", { name: "Sign In", exact: true }).click();
+
+  // Wait for redirect away from login page
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 15000 });
+}
+
+setup("authenticate organizer", async ({ page }) => {
+  await login(page, ORGANIZER.email, ORGANIZER.password);
+  await page.context().storageState({ path: ORGANIZER.storageState });
+});
+
+setup("authenticate participant", async ({ page }) => {
+  await login(page, PARTICIPANT.email, PARTICIPANT.password);
+  await page.context().storageState({ path: PARTICIPANT.storageState });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -13,7 +13,11 @@ test.describe("Login page", () => {
   test("has link to signup", async ({ page }) => {
     await page.goto("/login");
 
-    const signupLink = page.getByRole("link", { name: /sign up|create account|register/i });
+    // "Don't have an account? Sign Up" — scoped to main content (not navbar)
+    const signupLink = page
+      .getByRole("paragraph")
+      .filter({ hasText: /don't have an account/i })
+      .getByRole("link");
     await expect(signupLink).toBeVisible();
   });
 });
@@ -33,7 +37,11 @@ test.describe("Signup page", () => {
   test("has link to login", async ({ page }) => {
     await page.goto("/signup");
 
-    const loginLink = page.getByRole("link", { name: /log in|sign in/i });
+    // "Already have an account? Sign In" — scoped to main content (not navbar)
+    const loginLink = page
+      .getByRole("paragraph")
+      .filter({ hasText: /already have an account/i })
+      .getByRole("link");
     await expect(loginLink).toBeVisible();
   });
 });

--- a/e2e/booking-flow.spec.ts
+++ b/e2e/booking-flow.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "@playwright/test";
+
+const ORGANIZER_STATE = "e2e/.auth/organizer.json";
+const PARTICIPANT_STATE = "e2e/.auth/participant.json";
+
+test.describe("Organizer + Participant booking flow", () => {
+  let eventId: string;
+  let eventTitle: string;
+
+  test("full happy path: create → book → check-in → verify", async ({ browser }) => {
+    const organizerContext = await browser.newContext({ storageState: ORGANIZER_STATE });
+    const participantContext = await browser.newContext({ storageState: PARTICIPANT_STATE });
+
+    // ── Step 1: Create event via API ──────────────────────────────
+    await test.step("Organizer creates event via API", async () => {
+      const startDate = new Date(Date.now() + 47 * 60 * 60 * 1000);
+      eventTitle = `E2E Test Event ${String(Date.now())}`;
+
+      const response = await organizerContext.request.post("/api/events", {
+        data: {
+          title: eventTitle,
+          description: "Automated E2E test event — safe to delete.",
+          type: "hiking",
+          date: startDate.toISOString(),
+          location: "Mt. Pulag, Benguet",
+          max_participants: 20,
+          price: 0,
+          cover_image_url: "https://images.unsplash.com/photo-1551632811-561732d1e306?w=800",
+        },
+      });
+
+      expect(response.ok()).toBeTruthy();
+      const body = (await response.json()) as { event: { id: string } };
+      eventId = body.event.id;
+      expect(eventId).toBeTruthy();
+    });
+
+    // ── Step 2: Publish event via API ─────────────────────────────
+    await test.step("Organizer publishes event", async () => {
+      const response = await organizerContext.request.put(`/api/events/${eventId}`, {
+        data: { status: "published" },
+      });
+
+      expect(response.ok()).toBeTruthy();
+    });
+
+    // ── Step 3: Participant finds event on /events ────────────────
+    await test.step("Participant finds event on /events", async () => {
+      const participantPage = await participantContext.newPage();
+
+      await participantPage.goto("/events");
+      await expect(participantPage.getByRole("heading", { level: 1 })).toBeVisible();
+
+      // Look for our event card by title
+      const eventCard = participantPage.getByRole("link", { name: eventTitle });
+      await expect(eventCard).toBeVisible({ timeout: 10000 });
+      await eventCard.click();
+
+      // Should be on the event detail page
+      await expect(participantPage).toHaveURL(new RegExp(`/events/${eventId}`));
+      await expect(participantPage.getByRole("heading", { name: eventTitle })).toBeVisible();
+
+      await participantPage.close();
+    });
+
+    // ── Step 4: Participant books event ───────────────────────────
+    await test.step("Participant books event", async () => {
+      const participantPage = await participantContext.newPage();
+
+      await participantPage.goto(`/events/${eventId}/book`);
+
+      // Free event — just click confirm
+      const confirmButton = participantPage.getByRole("button", { name: /confirm booking/i });
+      await expect(confirmButton).toBeVisible({ timeout: 10000 });
+      await confirmButton.click();
+
+      // Booking confirmation shows "You're In!"
+      await expect(participantPage.getByText(/you're in/i)).toBeVisible({ timeout: 15000 });
+
+      await participantPage.close();
+    });
+
+    // ── Step 5: Participant self-checks-in from /my-events ───────
+    await test.step("Participant self-checks-in", async () => {
+      const participantPage = await participantContext.newPage();
+
+      await participantPage.goto("/my-events");
+
+      // Find the "Check In Online" button for our event
+      const checkInButton = participantPage.getByRole("button", { name: /check in online/i });
+      await expect(checkInButton).toBeVisible({ timeout: 10000 });
+      await checkInButton.click();
+
+      // Should show "Checked In" status
+      await expect(participantPage.getByText(/checked in/i).first()).toBeVisible({
+        timeout: 10000,
+      });
+
+      await participantPage.close();
+    });
+
+    // ── Step 6: Organizer sees check-in on dashboard ─────────────
+    await test.step("Organizer sees check-in on dashboard", async () => {
+      const organizerPage = await organizerContext.newPage();
+
+      await organizerPage.goto(`/dashboard/events/${eventId}`);
+
+      // Participants table should show "Checked in" for the participant
+      await expect(organizerPage.getByText("Checked in").first()).toBeVisible({ timeout: 10000 });
+
+      await organizerPage.close();
+    });
+
+    // Cleanup contexts
+    await organizerContext.close();
+    await participantContext.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (!eventId) return;
+
+    const context = await browser.newContext({ storageState: ORGANIZER_STATE });
+    await context.request.delete(`/api/events/${eventId}`);
+    await context.close();
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -17,11 +17,16 @@ test("homepage loads and shows key content", async ({ page }) => {
 test('"Explore Events" navigates to events page', async ({ page }) => {
   await page.goto("/");
 
+  // Wait for splash screen to clear (z-[100] overlay, ~400ms)
+  await page
+    .locator(String.raw`.z-\[100\]`)
+    .waitFor({ state: "hidden", timeout: 5000 })
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    .catch(() => {});
+
   const exploreLink = page.getByRole("link", { name: /explore events/i }).first();
   await expect(exploreLink).toHaveAttribute("href", "/events");
+  await exploreLink.click();
 
-  // Hero carousel images overlap the CTA; force click since visibility is verified above
-  await exploreLink.click({ force: true });
-
-  await expect(page).toHaveURL("/events");
+  await expect(page).toHaveURL("/events", { timeout: 10000 });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -15,12 +15,19 @@ test.describe("Navigation", () => {
   test("can navigate from homepage to events and back", async ({ page }) => {
     await page.goto("/");
 
-    // Navigate to events
+    // Wait for splash screen to clear (z-[100] overlay, ~400ms)
+    await page
+      .locator(String.raw`.z-\[100\]`)
+      .waitFor({ state: "hidden", timeout: 5000 })
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .catch(() => {});
+
+    // Navigate to events via the hero CTA link
     const exploreLink = page.getByRole("link", { name: /explore events/i }).first();
     await expect(exploreLink).toBeVisible();
-    await exploreLink.click({ force: true });
+    await exploreLink.click();
 
-    await expect(page).toHaveURL("/events");
+    await expect(page).toHaveURL("/events", { timeout: 10000 });
 
     // Navigate back via browser
     await page.goBack();

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "seed:cms": "pnpm tsx scripts/seed-cms.ts",
     "docs:sync": "ts-node --compiler-options {\\\"module\\\":\\\"commonjs\\\",\\\"target\\\":\\\"ES2017\\\"} scripts/sync-docs/index.ts",
     "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "test": "vitest run",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,14 @@ export default defineConfig({
   },
   projects: [
     {
+      name: "setup",
+      testMatch: /auth\.setup\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary
- Add Playwright auth setup project that logs in organizer + participant seed accounts and saves storageState
- Add full happy-path E2E spec: organizer creates/publishes event via API → participant finds, books, self-checks-in → organizer verifies check-in on dashboard
- Fix pre-existing failures in auth, home, and navigation specs (strict mode violations from navbar duplicate links, splash screen overlay blocking clicks)
- Add `test:e2e:ui` script for visual Playwright UI mode

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test:e2e` — 14/14 passing
- [ ] CI passes on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)