### PR TITLE
perf: defer Leaflet loading & dynamic import waitlist modal

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,3 +1,4 @@
+import dynamic from "next/dynamic";
 import { Suspense } from "react";
 
 import BentoEventsSection from "@/components/landing/BentoEventsSection";
@@ -10,7 +11,6 @@ import GamificationSection from "@/components/landing/GamificationSection";
 import HeroSection from "@/components/landing/HeroSection";
 import HowItWorksSection from "@/components/landing/HowItWorksSection";
 import OrganizersSection from "@/components/landing/OrganizersSection";
-import OrganizerWaitlistModal from "@/components/landing/OrganizerWaitlistModal";
 import ParallaxMountain from "@/components/landing/ParallaxMountain";
 import PioneerCounterSection from "@/components/landing/PioneerCounterSection";
 import StravaShowcaseSection from "@/components/landing/StravaShowcaseSection";
@@ -23,6 +23,8 @@ import {
   parseHomepageSections,
 } from "@/lib/cms/cached";
 import { type CmsHomepageSection } from "@/lib/cms/types";
+
+const OrganizerWaitlistModal = dynamic(() => import("@/components/landing/OrganizerWaitlistModal"));
 
 export const metadata = {
   title: "EventTara — Outdoor Adventure Events in Panay Island",

--- a/src/components/landing/StravaShowcaseRouteMap.tsx
+++ b/src/components/landing/StravaShowcaseRouteMap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useEffect, useRef, useState } from "react";
 
 const RouteMap = dynamic(() => import("@/components/strava/RouteMap"), {
   ssr: false,
@@ -24,12 +25,40 @@ const COASTAL_ROAD_DISTANCE = 110_000; // 110 km out-and-back
 const COASTAL_ROAD_ELEVATION = 650; // meters
 
 export default function StravaShowcaseRouteMap() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <RouteMap
-      polyline={COASTAL_ROAD_POLYLINE}
-      distance={COASTAL_ROAD_DISTANCE}
-      elevationGain={COASTAL_ROAD_ELEVATION}
-      className="rounded-xl shadow-lg"
-    />
+    <div ref={ref}>
+      {visible ? (
+        <RouteMap
+          polyline={COASTAL_ROAD_POLYLINE}
+          distance={COASTAL_ROAD_DISTANCE}
+          elevationGain={COASTAL_ROAD_ELEVATION}
+          className="rounded-xl shadow-lg"
+        />
+      ) : (
+        <div
+          className="animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800"
+          style={{ height: 300 }}
+        />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Gate `StravaShowcaseRouteMap` with `IntersectionObserver` so the Leaflet chunk (~44 KiB transfer) only loads when the user scrolls near the Strava showcase section, instead of loading on initial page hydration
- Dynamic import `OrganizerWaitlistModal` on the homepage since it's a modal behind a 3-second delay

## Context
Lighthouse flagged ~130 KiB of unused JavaScript on the homepage:
- **1st party (97.8 KiB, 69.7 KiB savings)**: Supabase client (~54 KiB, unavoidable for auth) + Leaflet (~44 KiB, now deferred)
- **Google Tag Manager (147.7 KiB, 60.5 KiB savings)**: Already using `lazyOnload` strategy, 3rd party — not in our control

## Test plan
- [ ] Homepage loads without Leaflet chunk in initial network waterfall
- [ ] Scroll to Strava showcase section — map loads correctly
- [ ] Waitlist modal still appears after 3s delay
- [ ] Run Lighthouse on homepage — verify reduced "Unused JavaScript" score

🤖 Generated with [Claude Code](https://claude.com/claude-code)