### PR TITLE
fix: remove stale OrganizerWaitlistModal dynamic import

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,4 +1,3 @@
-import dynamic from "next/dynamic";
 import { Suspense } from "react";
 
 import BentoEventsSection from "@/components/landing/BentoEventsSection";
@@ -24,8 +23,6 @@ import {
   parseHomepageSections,
 } from "@/lib/cms/cached";
 import { type CmsHomepageSection } from "@/lib/cms/types";
-
-const OrganizerWaitlistModal = dynamic(() => import("@/components/landing/OrganizerWaitlistModal"));
 
 export const metadata = {
   title: "EventTara — Outdoor Adventure Events in Panay Island",


### PR DESCRIPTION
## Summary
- Remove leftover `dynamic()` import of deleted `OrganizerWaitlistModal` that was causing a lint error on staging CI
- Also removes the now-unused `next/dynamic` import

## Test plan
- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)