### PR TITLE
perf: improve homepage LCP and fix admin env for staging/dev

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -36,3 +36,4 @@ STRAVA_WEBHOOK_VERIFY_TOKEN=a-random-string-for-webhook-verification
 
 # Admin panel (comma-separated Supabase user IDs)
 ADMIN_USER_IDS=
+ADMIN_DEV_STAGING_USER_IDS=

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -102,7 +102,14 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     getCachedHeroCarousel(),
   ]);
   const navLayout = settings?.nav_layout || "strip";
-  const adminUserIds = (process.env.ADMIN_USER_IDS ?? "")
+  const isProduction = (process.env.VERCEL_ENV ?? process.env.NODE_ENV) === "production";
+  const adminUserIds = (
+    isProduction
+      ? (process.env.ADMIN_USER_IDS ?? "")
+      : [process.env.ADMIN_USER_IDS, process.env.ADMIN_DEV_STAGING_USER_IDS]
+          .filter(Boolean)
+          .join(",")
+  )
     .split(",")
     .map((id) => id.trim())
     .filter(Boolean);
@@ -115,9 +122,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     >
       <head>
         {process.env.NEXT_PUBLIC_SUPABASE_URL && (
-          <link rel="preconnect" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
+          <>
+            <link rel="preconnect" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
+            <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
+          </>
         )}
         <link rel="preconnect" href="https://images.unsplash.com" />
+        <link rel="dns-prefetch" href="https://images.unsplash.com" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/components/landing/BentoEventCard.tsx
+++ b/src/components/landing/BentoEventCard.tsx
@@ -59,6 +59,7 @@ export default function BentoEventCard({ event, variant }: BentoEventCardProps) 
               alt={event.title}
               fill
               sizes="(max-width: 768px) 92vw, (max-width: 1280px) 33vw, 400px"
+              quality={60}
               className="object-cover transition-transform duration-500 group-hover:scale-105"
             />
           )}
@@ -169,6 +170,7 @@ export default function BentoEventCard({ event, variant }: BentoEventCardProps) 
             alt={event.title}
             fill
             sizes="(max-width: 768px) 80vw, (max-width: 1280px) 22vw, 280px"
+            quality={60}
             className="object-cover transition-transform duration-500 group-hover:scale-105"
           />
         )}

--- a/src/components/landing/HeroCarousel.tsx
+++ b/src/components/landing/HeroCarousel.tsx
@@ -36,10 +36,32 @@ export default function HeroCarousel({ slides }: HeroCarouselProps) {
                 : undefined
             }
           >
-            <picture>
-              {slide.image.mobileUrl && (
-                <source media="(max-width: 1024px)" srcSet={slide.image.mobileUrl} />
-              )}
+            {slide.image.mobileUrl ? (
+              <>
+                {/* Mobile-optimized image (hidden on desktop) */}
+                <Image
+                  src={slide.image.mobileUrl}
+                  alt={slide.image.alt || "Adventure"}
+                  fill
+                  className="object-cover lg:hidden"
+                  sizes="(max-width: 1024px) 100vw, 0px"
+                  quality={50}
+                  priority={i === 0}
+                  fetchPriority={i === 0 ? "high" : "auto"}
+                  loading={i === 0 ? "eager" : "lazy"}
+                />
+                {/* Desktop image (hidden on mobile) */}
+                <Image
+                  src={slide.image.url}
+                  alt={slide.image.alt || "Adventure"}
+                  fill
+                  className="hidden object-cover lg:block"
+                  sizes="(min-width: 1025px) 100vw, 0px"
+                  quality={50}
+                  loading={i === 0 ? "eager" : "lazy"}
+                />
+              </>
+            ) : (
               <Image
                 src={slide.image.url}
                 alt={slide.image.alt || "Adventure"}
@@ -51,7 +73,7 @@ export default function HeroCarousel({ slides }: HeroCarouselProps) {
                 fetchPriority={i === 0 ? "high" : "auto"}
                 loading={i === 0 ? "eager" : "lazy"}
               />
-            </picture>
+            )}
           </div>
         );
       })}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,19 +1,8 @@
-import dynamic from "next/dynamic";
 import Link from "next/link";
 
 import AnimatedLogo from "@/components/landing/AnimatedLogo";
 import HeroCarousel from "@/components/landing/HeroCarousel";
-
-const HostEventLink = dynamic(() => import("@/components/landing/HostEventLink"), {
-  loading: () => (
-    <Link
-      href="/signup?role=organizer"
-      className="inline-flex items-center justify-center font-semibold rounded-xl text-lg py-4 px-8 border-2 border-gray-300 dark:border-slate-600 text-gray-600 dark:text-gray-300 hover:border-lime-500 hover:text-lime-600 dark:hover:text-lime-400 transition-colors"
-    >
-      Host Your Event
-    </Link>
-  ),
-});
+import HostEventLink from "@/components/landing/HostEventLink";
 
 interface HeroSlide {
   image: { url: string; mobileUrl?: string; alt: string };

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -1,10 +1,25 @@
 /**
- * Check whether a Supabase user ID is in the ADMIN_USER_IDS allow-list.
- * The env var is a comma-separated string of UUIDs.
+ * Check whether a Supabase user ID is in the admin allow-list.
+ * Uses ADMIN_DEV_STAGING_USER_IDS on preview/development deployments,
+ * ADMIN_USER_IDS on production. The env var is a comma-separated string of UUIDs.
  */
 export function isAdminUser(userId: string): boolean {
-  const raw = process.env.ADMIN_USER_IDS ?? "";
-  if (!raw) return false;
-  const ids = raw.split(",").map((id) => id.trim());
-  return ids.includes(userId);
+  const env = process.env.VERCEL_ENV ?? process.env.NODE_ENV;
+  if (env === "production") {
+    const raw = process.env.ADMIN_USER_IDS ?? "";
+    if (!raw) return false;
+    return raw
+      .split(",")
+      .map((id) => id.trim())
+      .includes(userId);
+  }
+  // Non-production: merge both lists so prod + staging/dev admins all have access
+  const parts = [process.env.ADMIN_USER_IDS, process.env.ADMIN_DEV_STAGING_USER_IDS]
+    .filter(Boolean)
+    .join(",");
+  if (!parts) return false;
+  return parts
+    .split(",")
+    .map((id) => id.trim())
+    .includes(userId);
 }


### PR DESCRIPTION
## Summary
- **Fix hero image LCP on mobile**: Replaced `<picture>` + raw `<source srcSet>` with dual Next.js `<Image>` components so mobile hero images go through optimization (avif/webp, resizing) instead of loading raw URLs from Supabase storage
- **Remove unnecessary dynamic import**: `HostEventLink` is lightweight (28 lines) and above-fold — static import eliminates an extra chunk request
- **Add dns-prefetch hints**: For Supabase and Unsplash domains to start DNS resolution earlier
- **Reduce event card image sizes**: Added `quality={60}` to `BentoEventCard` images (~20% smaller files)
- **Fix admin env for staging/dev**: Use `ADMIN_DEV_STAGING_USER_IDS` env var for non-production, merging both admin ID lists so all admins work across environments

## Lighthouse Before (Homepage)
| Device | Score | LCP | FCP | TBT | CLS |
|--------|-------|-----|-----|-----|-----|
| Mobile | 69 | 7.2s | 2.1s | 0ms | 0 |
| Desktop | 60 | 5.0s | 2.1s | 10ms | 0.012 |

## Test plan
- [ ] Verify hero carousel displays correctly on mobile and desktop
- [ ] Verify admin panel accessible locally with `ADMIN_USER_IDS` user
- [ ] Verify admin panel accessible on staging with `ADMIN_DEV_STAGING_USER_IDS` user
- [ ] Run Lighthouse after deploy to compare LCP scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)