### PR TITLE
fix: hide onboarding quiz for logged-in users

### DIFF
--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -290,7 +290,7 @@ export default function ClientShell({
           onLogout={() => void handleLogout()}
         />
 
-        <OnboardingQuizModal featureFlags={featureFlags} />
+        {!user && <OnboardingQuizModal featureFlags={featureFlags} />}
         <ChatBubble />
         <InstallPrompt />
         {showDebugPanel && user && (


### PR DESCRIPTION
## Summary
- Skip rendering `OnboardingQuizModal` when a user is authenticated
- The quiz is only relevant for new/anonymous visitors

## Test plan
- [ ] Log out — quiz appears as before
- [ ] Log in — quiz does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)