### PR TITLE
feat: block reserved usernames

### DIFF
--- a/src/app/(frontend)/(auth)/setup-username/page.tsx
+++ b/src/app/(frontend)/(auth)/setup-username/page.tsx
@@ -5,6 +5,7 @@ import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 
 import { CheckCircleIcon } from "@/components/icons";
 import { Button } from "@/components/ui";
+import { isReservedUsername } from "@/lib/constants/reserved-usernames";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 
@@ -35,7 +36,7 @@ function SetupUsernameForm() {
 
   const [username, setUsername] = useState("");
   const [usernameStatus, setUsernameStatus] = useState<
-    "idle" | "checking" | "available" | "taken" | "invalid"
+    "idle" | "checking" | "available" | "taken" | "invalid" | "reserved"
   >("idle");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -84,6 +85,10 @@ function SetupUsernameForm() {
     }
     if (!USERNAME_REGEX.test(normalized)) {
       setUsernameStatus("invalid");
+      return;
+    }
+    if (isReservedUsername(normalized)) {
+      setUsernameStatus("reserved");
       return;
     }
 
@@ -229,7 +234,9 @@ function SetupUsernameForm() {
                   "w-full pl-8 pr-10 py-3 rounded-xl border bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 outline-none transition-colors",
                   usernameStatus === "available"
                     ? "border-green-500 focus:border-green-500 focus:ring-2 focus:ring-green-200 dark:focus:ring-green-800"
-                    : usernameStatus === "taken" || usernameStatus === "invalid"
+                    : usernameStatus === "taken" ||
+                        usernameStatus === "invalid" ||
+                        usernameStatus === "reserved"
                       ? "border-red-500 focus:border-red-500 focus:ring-2 focus:ring-red-200 dark:focus:ring-red-800"
                       : "border-gray-300 dark:border-gray-600 focus:border-lime-500 focus:ring-2 focus:ring-lime-200 dark:focus:ring-lime-800",
                 )}
@@ -265,7 +272,7 @@ function SetupUsernameForm() {
                     />
                   </svg>
                 )}
-                {usernameStatus === "taken" && (
+                {(usernameStatus === "taken" || usernameStatus === "reserved") && (
                   <svg className="h-4 w-4 text-red-500" viewBox="0 0 20 20" fill="currentColor">
                     <path
                       fillRule="evenodd"
@@ -278,6 +285,9 @@ function SetupUsernameForm() {
             </div>
             {usernameStatus === "taken" && (
               <p className="text-xs text-red-500">This username is already taken</p>
+            )}
+            {usernameStatus === "reserved" && (
+              <p className="text-xs text-red-500">This username is reserved</p>
             )}
             {usernameStatus === "invalid" && username.length > 0 && (
               <p className="text-xs text-red-500">
@@ -295,7 +305,12 @@ function SetupUsernameForm() {
             type="submit"
             className="w-full"
             size="lg"
-            disabled={loading || usernameStatus === "taken" || usernameStatus === "invalid"}
+            disabled={
+              loading ||
+              usernameStatus === "taken" ||
+              usernameStatus === "invalid" ||
+              usernameStatus === "reserved"
+            }
           >
             {loading ? "Setting up..." : "Continue"}
           </Button>

--- a/src/app/(frontend)/(auth)/signup/page.tsx
+++ b/src/app/(frontend)/(auth)/signup/page.tsx
@@ -6,6 +6,7 @@ import { Suspense, useState, useEffect, useRef, useCallback } from "react";
 
 import { CheckCircleIcon, GoogleIcon, StravaIcon } from "@/components/icons";
 import { Button, Input, OtpCodeInput } from "@/components/ui";
+import { isReservedUsername } from "@/lib/constants/reserved-usernames";
 import { STRAVA_AUTH_URL, STRAVA_SCOPES } from "@/lib/strava/constants";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
@@ -35,7 +36,7 @@ function SignupForm() {
   // Username field
   const [username, setUsername] = useState("");
   const [usernameStatus, setUsernameStatus] = useState<
-    "idle" | "checking" | "available" | "taken" | "invalid"
+    "idle" | "checking" | "available" | "taken" | "invalid" | "reserved"
   >("idle");
   const usernameTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -71,6 +72,10 @@ function SignupForm() {
     }
     if (!USERNAME_REGEX.test(normalized)) {
       setUsernameStatus("invalid");
+      return;
+    }
+    if (isReservedUsername(normalized)) {
+      setUsernameStatus("reserved");
       return;
     }
 
@@ -514,7 +519,9 @@ function SignupForm() {
                   "w-full pl-8 pr-10 py-3 rounded-xl border bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 outline-none transition-colors",
                   usernameStatus === "available"
                     ? "border-green-500 focus:border-green-500 focus:ring-2 focus:ring-green-200 dark:focus:ring-green-800"
-                    : usernameStatus === "taken" || usernameStatus === "invalid"
+                    : usernameStatus === "taken" ||
+                        usernameStatus === "invalid" ||
+                        usernameStatus === "reserved"
                       ? "border-red-500 focus:border-red-500 focus:ring-2 focus:ring-red-200 dark:focus:ring-red-800"
                       : "border-gray-300 dark:border-gray-600 focus:border-lime-500 focus:ring-2 focus:ring-lime-200 dark:focus:ring-lime-800",
                 )}
@@ -550,7 +557,7 @@ function SignupForm() {
                     />
                   </svg>
                 )}
-                {usernameStatus === "taken" && (
+                {(usernameStatus === "taken" || usernameStatus === "reserved") && (
                   <svg className="h-4 w-4 text-red-500" viewBox="0 0 20 20" fill="currentColor">
                     <path
                       fillRule="evenodd"
@@ -563,6 +570,9 @@ function SignupForm() {
             </div>
             {usernameStatus === "taken" && (
               <p className="text-xs text-red-500">This username is already taken</p>
+            )}
+            {usernameStatus === "reserved" && (
+              <p className="text-xs text-red-500">This username is reserved</p>
             )}
             {usernameStatus === "invalid" && username.length > 0 && (
               <p className="text-xs text-red-500">

--- a/src/app/(frontend)/api/users/check-username/route.ts
+++ b/src/app/(frontend)/api/users/check-username/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 
+import { isReservedUsername } from "@/lib/constants/reserved-usernames";
 import { createClient } from "@/lib/supabase/server";
 
 const USERNAME_REGEX = /^[a-z0-9._-]{3,30}$/;
@@ -20,6 +21,10 @@ export async function GET(request: NextRequest) {
       },
       { status: 400 },
     );
+  }
+
+  if (isReservedUsername(username)) {
+    return NextResponse.json({ available: false, error: "This username is reserved" });
   }
 
   const supabase = await createClient();

--- a/src/app/(frontend)/api/users/set-username/route.ts
+++ b/src/app/(frontend)/api/users/set-username/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { isReservedUsername } from "@/lib/constants/reserved-usernames";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 
 const USERNAME_REGEX = /^[a-z0-9._-]{3,30}$/;
@@ -60,6 +61,10 @@ export async function POST(request: Request) {
       },
       { status: 400 },
     );
+  }
+
+  if (isReservedUsername(username)) {
+    return NextResponse.json({ error: "This username is reserved." }, { status: 400 });
   }
 
   // Check availability

--- a/src/components/reviews/AuthReviewModal.tsx
+++ b/src/components/reviews/AuthReviewModal.tsx
@@ -11,6 +11,7 @@ import {
   StravaIcon,
 } from "@/components/icons";
 import { Button, OtpCodeInput } from "@/components/ui";
+import { isReservedUsername } from "@/lib/constants/reserved-usernames";
 import { STRAVA_AUTH_URL, STRAVA_SCOPES } from "@/lib/strava/constants";
 import { createClient } from "@/lib/supabase/client";
 import { generateUsername } from "@/lib/utils/generate-username";
@@ -18,7 +19,7 @@ import { generateUsername } from "@/lib/utils/generate-username";
 type ModalState = "form" | "verify-code" | "guest" | "success";
 type AuthMethod = "password" | "otp";
 type AuthMode = "login" | "signup";
-type UsernameStatus = "idle" | "checking" | "available" | "taken" | "invalid";
+type UsernameStatus = "idle" | "checking" | "available" | "taken" | "invalid" | "reserved";
 
 const CODE_LENGTH = 6;
 const USERNAME_REGEX = /^[a-z0-9._-]{3,30}$/;
@@ -131,6 +132,10 @@ export default function AuthReviewModal({
     }
     if (!USERNAME_REGEX.test(normalized)) {
       setUsernameStatus("invalid");
+      return;
+    }
+    if (isReservedUsername(normalized)) {
+      setUsernameStatus("reserved");
       return;
     }
 
@@ -656,6 +661,11 @@ export default function AuthReviewModal({
                       {usernameStatus === "taken" && (
                         <span className="ml-2 text-sm font-normal text-red-600 dark:text-red-400">
                           ✗ Taken
+                        </span>
+                      )}
+                      {usernameStatus === "reserved" && (
+                        <span className="ml-2 text-sm font-normal text-red-600 dark:text-red-400">
+                          ✗ Reserved
                         </span>
                       )}
                       {usernameStatus === "invalid" && (

--- a/src/lib/constants/reserved-usernames.ts
+++ b/src/lib/constants/reserved-usernames.ts
@@ -1,0 +1,91 @@
+/**
+ * Usernames that cannot be claimed by regular users.
+ * Checked case-insensitively against the normalized (lowercased) input.
+ */
+export const RESERVED_USERNAMES = new Set([
+  // Platform roles & authority
+  "admin",
+  "administrator",
+  "moderator",
+  "mod",
+  "superadmin",
+  "sysadmin",
+  "root",
+  "owner",
+  "staff",
+  "team",
+  "support",
+  "helpdesk",
+
+  // Brand / product
+  "eventtara",
+  "event-tara",
+  "event.tara",
+  "tara",
+  "official",
+  "verified",
+
+  // System / technical
+  "system",
+  "bot",
+  "api",
+  "webhook",
+  "noreply",
+  "no-reply",
+  "mailer",
+  "postmaster",
+  "webmaster",
+  "info",
+  "contact",
+  "security",
+  "abuse",
+
+  // Common impersonation targets
+  "ceo",
+  "cto",
+  "cfo",
+  "founder",
+  "cofounder",
+
+  // Reserved paths that could collide with routes
+  "login",
+  "signup",
+  "register",
+  "logout",
+  "settings",
+  "dashboard",
+  "profile",
+  "account",
+  "feed",
+  "events",
+  "explore",
+  "search",
+  "notifications",
+  "messages",
+  "about",
+  "help",
+  "terms",
+  "privacy",
+  "billing",
+  "pricing",
+  "clubs",
+  "guides",
+  "bookings",
+  "my-events",
+
+  // Generic reserved
+  "test",
+  "demo",
+  "example",
+  "null",
+  "undefined",
+  "anonymous",
+  "guest",
+  "unknown",
+  "deleted",
+  "user",
+]);
+
+export function isReservedUsername(username: string): boolean {
+  return RESERVED_USERNAMES.has(username.toLowerCase().trim());
+}


### PR DESCRIPTION
## Summary
- Adds a shared list of ~80 reserved usernames (admin, moderator, system, eventtara, dashboard, events, etc.)
- Blocks reserved names client-side with instant "reserved" feedback (red border + message)
- Blocks server-side in both `check-username` and `set-username` API routes as a safety net
- Applied to all 3 username entry points: signup page, setup-username page, and AuthReviewModal

## Test plan
- [ ] Try typing "admin" as username on signup — should show "This username is reserved" instantly
- [ ] Try "dashboard", "events", "system" — same behavior
- [ ] Try a normal username like "john.doe" — should check availability as usual
- [ ] Verify the API rejects reserved usernames even if client-side check is bypassed

🤖 Generated with [Claude Code](https://claude.com/claude-code)