### PR TITLE
fix: add missing page metadata

### DIFF
--- a/src/app/(frontend)/(auth)/forgot-password/layout.tsx
+++ b/src/app/(frontend)/(auth)/forgot-password/layout.tsx
@@ -1,0 +1,10 @@
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Forgot Password",
+  description: "Reset your EventTara password.",
+};
+
+export default function ForgotPasswordLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(frontend)/(auth)/layout.tsx
+++ b/src/app/(frontend)/(auth)/layout.tsx
@@ -1,3 +1,10 @@
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+  description: "Sign in or create an account on EventTara to book outdoor adventure events.",
+};
+
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-dvh bg-gray-50 dark:bg-gray-800 flex items-center justify-center p-4">

--- a/src/app/(frontend)/(auth)/login/layout.tsx
+++ b/src/app/(frontend)/(auth)/login/layout.tsx
@@ -1,0 +1,10 @@
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+  description: "Sign in to your EventTara account.",
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(frontend)/(auth)/reset-password/layout.tsx
+++ b/src/app/(frontend)/(auth)/reset-password/layout.tsx
@@ -1,0 +1,10 @@
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Reset Password",
+  description: "Set a new password for your EventTara account.",
+};
+
+export default function ResetPasswordLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(frontend)/(auth)/signup/layout.tsx
+++ b/src/app/(frontend)/(auth)/signup/layout.tsx
@@ -1,0 +1,10 @@
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign Up",
+  description: "Create your EventTara account and start booking outdoor adventure events.",
+};
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(frontend)/(organizer)/dashboard/events/[id]/checkin/page.tsx
+++ b/src/app/(frontend)/(organizer)/dashboard/events/[id]/checkin/page.tsx
@@ -1,3 +1,4 @@
+import { type Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -7,6 +8,20 @@ import { ChevronLeftIcon } from "@/components/icons";
 import type { BorderTier } from "@/lib/constants/avatar-borders";
 import { BreadcrumbTitle } from "@/lib/contexts/BreadcrumbContext";
 import { createClient } from "@/lib/supabase/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: event } = await supabase.from("events").select("title").eq("id", id).single();
+
+  return {
+    title: event ? `Check-in · ${event.title}` : "Check-in",
+  };
+}
 
 export default async function CheckinPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/src/app/(frontend)/(organizer)/dashboard/events/[id]/page.tsx
+++ b/src/app/(frontend)/(organizer)/dashboard/events/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { type Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -12,6 +13,20 @@ import { Button, UIBadge } from "@/components/ui";
 import type { BorderTier } from "@/lib/constants/avatar-borders";
 import { BreadcrumbTitle } from "@/lib/contexts/BreadcrumbContext";
 import { createClient } from "@/lib/supabase/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: event } = await supabase.from("events").select("title").eq("id", id).single();
+
+  return {
+    title: event ? `Manage ${event.title}` : "Manage Event",
+  };
+}
 
 export default async function ManageEventPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/src/app/(frontend)/(participant)/contact/layout.tsx
+++ b/src/app/(frontend)/(participant)/contact/layout.tsx
@@ -1,0 +1,10 @@
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact Us",
+  description: "Get in touch with the EventTara team for questions, feedback, or support.",
+};
+
+export default function ContactLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(frontend)/(participant)/events/[id]/book/page.tsx
+++ b/src/app/(frontend)/(participant)/events/[id]/book/page.tsx
@@ -1,9 +1,27 @@
+import { type Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 
 import BookingPageClient from "@/components/booking/BookingPageClient";
 import { Breadcrumbs } from "@/components/ui";
 import { BreadcrumbTitle } from "@/lib/contexts/BreadcrumbContext";
 import { createClient } from "@/lib/supabase/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: event } = await supabase.from("events").select("title").eq("id", id).single();
+
+  return {
+    title: event ? `Book ${event.title}` : "Book Event",
+    description: event
+      ? `Reserve your spot for ${event.title} on EventTara.`
+      : "Reserve your spot for this outdoor adventure event.",
+  };
+}
 
 export default async function BookEventPage({
   params,

--- a/src/app/(frontend)/(participant)/events/[id]/review/page.tsx
+++ b/src/app/(frontend)/(participant)/events/[id]/review/page.tsx
@@ -20,7 +20,12 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const supabase = await createClient();
   const { data: event } = await supabase.from("events").select("title").eq("id", id).single();
 
-  return { title: event ? `Review ${event.title}` : "Review Event" };
+  return {
+    title: event ? `Review ${event.title}` : "Review Event",
+    description: event
+      ? `Share your experience at ${event.title} on EventTara.`
+      : "Share your experience at this event.",
+  };
 }
 
 export default async function EventReviewPage({ params }: { params: Promise<{ id: string }> }) {

--- a/src/app/(frontend)/(participant)/notifications/layout.tsx
+++ b/src/app/(frontend)/(participant)/notifications/layout.tsx
@@ -1,0 +1,9 @@
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Notifications",
+};
+
+export default function NotificationsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(frontend)/(participant)/post/[id]/page.tsx
+++ b/src/app/(frontend)/(participant)/post/[id]/page.tsx
@@ -11,6 +11,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export const metadata: Metadata = {
   title: "Post",
+  description: "View activity on EventTara.",
 };
 
 interface RawActivity {

--- a/src/app/(frontend)/claim/[token]/page.tsx
+++ b/src/app/(frontend)/claim/[token]/page.tsx
@@ -1,9 +1,31 @@
+import { type Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
 
 import ClaimForm from "./ClaimForm";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}): Promise<Metadata> {
+  const { token } = await params;
+  const supabase = await createClient();
+  const { data: club } = await supabase
+    .from("clubs")
+    .select("name")
+    .eq("claim_token", token)
+    .single();
+
+  return {
+    title: club ? `Claim ${club.name}` : "Claim Club",
+    description: club
+      ? `Claim ownership of ${club.name} on EventTara.`
+      : "Claim your club on EventTara.",
+  };
+}
 
 export default async function ClaimPage({ params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;


### PR DESCRIPTION
## Summary
- Added `generateMetadata` to server component pages: claim, book event, review event, dashboard event detail, dashboard check-in
- Added description to existing review page metadata
- Added description to post detail page
- Added metadata to auth layout as fallback for all auth pages
- Created layout wrappers with metadata for client component pages: login, signup, forgot password, reset password, contact, notifications

## Test plan
- [ ] Verify page titles appear correctly in browser tabs for all modified pages
- [ ] Confirm auth pages (login, signup, forgot/reset password) show correct titles
- [ ] Check dashboard pages show dynamic event titles
- [ ] Verify claim page shows club name in title

🤖 Generated with [Claude Code](https://claude.com/claude-code)