### PR TITLE
chore: add unit tests for new features and testing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,9 +173,43 @@ Floating chat bubble on every page (`src/components/chat/`). Powered by Anthropi
 
 ### Testing
 
-- **Unit tests** (Vitest 4): `src/lib/**/__tests__/*.test.ts`. Config at `vitest.config.mts`. Globals enabled (`describe`, `test`, `expect`, `vi` available without import).
-- **E2E tests** (Playwright): `e2e/*.spec.ts`. Config at `playwright.config.ts`. Uses chromium only, port 3001.
-- **CI**: GitHub Actions (`.github/workflows/ci.yml`). Unit tests on every PR + push. E2E only on push to main with Supabase secrets.
+**Every new feature or bugfix must include tests.** Unit tests for business logic and utility functions; E2E tests for user-facing workflows.
+
+#### Unit Tests (Vitest 4)
+
+- **Location:** `src/lib/<module>/__tests__/<module>.test.ts` — colocated with the code they test.
+- **Config:** `vitest.config.mts`. Globals enabled (`describe`, `test`, `expect`, `vi` available without import). Environment: `node`. Path alias `@/*` works.
+- **What to test:** Pure functions, utility helpers, validation logic, constants, normalization logic. Extract testable logic from API routes into `src/lib/` when possible.
+- **What NOT to unit test:** React components (use E2E instead), Supabase queries that just delegate to the client.
+
+**Supabase mock pattern:**
+
+```typescript
+function createMockSupabase(overrides: Record<string, unknown> = {}) {
+  const chainable = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    single: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    ...overrides,
+  };
+  return { from: vi.fn().mockReturnValue(chainable), _chain: chainable } as any;
+}
+```
+
+#### E2E Tests (Playwright)
+
+- **Location:** `e2e/*.spec.ts`. Config at `playwright.config.ts`. Chromium only, port 3001.
+- **Auth:** Setup in `e2e/auth.setup.ts` saves organizer + participant state to `e2e/.auth/`. Tests reuse via `storageState`.
+- **Patterns:** Use `test.step()` for multi-step flows. Prefer accessible selectors (`getByRole`, `getByLabel`) over CSS. Timeouts at 10s for async UI.
+
+#### CI
+
+GitHub Actions (`.github/workflows/ci.yml`). Unit tests on every PR + push. E2E only on push to main/staging with Supabase secrets.
+
+**Run before creating PRs:** `pnpm typecheck && pnpm lint && pnpm test`
 
 ### State Management
 

--- a/src/lib/constants/__tests__/reserved-usernames.test.ts
+++ b/src/lib/constants/__tests__/reserved-usernames.test.ts
@@ -1,0 +1,58 @@
+import { isReservedUsername, RESERVED_USERNAMES } from "../reserved-usernames";
+
+describe("RESERVED_USERNAMES", () => {
+  test("contains platform roles", () => {
+    expect(RESERVED_USERNAMES.has("admin")).toBe(true);
+    expect(RESERVED_USERNAMES.has("moderator")).toBe(true);
+    expect(RESERVED_USERNAMES.has("superadmin")).toBe(true);
+  });
+
+  test("contains brand names", () => {
+    expect(RESERVED_USERNAMES.has("eventtara")).toBe(true);
+    expect(RESERVED_USERNAMES.has("tara")).toBe(true);
+  });
+
+  test("contains route-colliding paths", () => {
+    expect(RESERVED_USERNAMES.has("login")).toBe(true);
+    expect(RESERVED_USERNAMES.has("signup")).toBe(true);
+    expect(RESERVED_USERNAMES.has("dashboard")).toBe(true);
+    expect(RESERVED_USERNAMES.has("events")).toBe(true);
+    expect(RESERVED_USERNAMES.has("feed")).toBe(true);
+    expect(RESERVED_USERNAMES.has("clubs")).toBe(true);
+  });
+
+  test("does not contain normal usernames", () => {
+    expect(RESERVED_USERNAMES.has("maria")).toBe(false);
+    expect(RESERVED_USERNAMES.has("trailrunner42")).toBe(false);
+    expect(RESERVED_USERNAMES.has("hiking_fan")).toBe(false);
+  });
+});
+
+describe("isReservedUsername", () => {
+  test("returns true for reserved usernames", () => {
+    expect(isReservedUsername("admin")).toBe(true);
+    expect(isReservedUsername("eventtara")).toBe(true);
+    expect(isReservedUsername("dashboard")).toBe(true);
+  });
+
+  test("is case-insensitive", () => {
+    expect(isReservedUsername("Admin")).toBe(true);
+    expect(isReservedUsername("ADMIN")).toBe(true);
+    expect(isReservedUsername("EventTara")).toBe(true);
+  });
+
+  test("trims whitespace", () => {
+    expect(isReservedUsername("  admin  ")).toBe(true);
+    expect(isReservedUsername("admin ")).toBe(true);
+  });
+
+  test("returns false for normal usernames", () => {
+    expect(isReservedUsername("maria")).toBe(false);
+    expect(isReservedUsername("trail_runner")).toBe(false);
+    expect(isReservedUsername("hiker2024")).toBe(false);
+  });
+
+  test("returns false for empty string", () => {
+    expect(isReservedUsername("")).toBe(false);
+  });
+});

--- a/src/lib/feed/__tests__/types.test.ts
+++ b/src/lib/feed/__tests__/types.test.ts
@@ -1,0 +1,44 @@
+import { EMOJI_ICON, type ActivityType, type FeedItem } from "../types";
+
+describe("ActivityType", () => {
+  test("includes all expected activity types", () => {
+    const types: ActivityType[] = ["booking", "checkin", "badge", "border", "review"];
+
+    // Verify each is assignable to ActivityType (compile-time check enforced by TS)
+    for (const t of types) {
+      expect(typeof t).toBe("string");
+    }
+    expect(types).toHaveLength(5);
+  });
+});
+
+describe("FeedItem", () => {
+  test("review fields are present on FeedItem shape", () => {
+    const item: Pick<FeedItem, "reviewRating" | "reviewText" | "activityType"> = {
+      activityType: "review",
+      reviewRating: 5,
+      reviewText: "Great event!",
+    };
+
+    expect(item.reviewRating).toBe(5);
+    expect(item.reviewText).toBe("Great event!");
+    expect(item.activityType).toBe("review");
+  });
+
+  test("review fields can be null for non-review activities", () => {
+    const item: Pick<FeedItem, "reviewRating" | "reviewText" | "activityType"> = {
+      activityType: "booking",
+      reviewRating: null,
+      reviewText: null,
+    };
+
+    expect(item.reviewRating).toBeNull();
+    expect(item.reviewText).toBeNull();
+  });
+});
+
+describe("EMOJI_ICON", () => {
+  test("is green heart emoji", () => {
+    expect(EMOJI_ICON).toBe("\u{1F49A}");
+  });
+});

--- a/src/lib/notifications/__tests__/resolve-activity-owner.test.ts
+++ b/src/lib/notifications/__tests__/resolve-activity-owner.test.ts
@@ -1,0 +1,66 @@
+import { resolveActivityOwner } from "../resolve-activity-owner";
+
+function createMockSupabase(overrides: Record<string, unknown> = {}) {
+  const chainable = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockReturnThis(),
+    ...overrides,
+  };
+  return { from: vi.fn().mockReturnValue(chainable), _chain: chainable } as any;
+}
+
+describe("resolveActivityOwner", () => {
+  test("resolves booking owner", async () => {
+    const supabase = createMockSupabase();
+    supabase._chain.single.mockResolvedValue({ data: { user_id: "user-1" } });
+
+    const result = await resolveActivityOwner(supabase, "booking", "booking-id");
+    expect(supabase.from).toHaveBeenCalledWith("bookings");
+    expect(result).toBe("user-1");
+  });
+
+  test("resolves checkin owner", async () => {
+    const supabase = createMockSupabase();
+    supabase._chain.single.mockResolvedValue({ data: { user_id: "user-2" } });
+
+    const result = await resolveActivityOwner(supabase, "checkin", "checkin-id");
+    expect(supabase.from).toHaveBeenCalledWith("event_checkins");
+    expect(result).toBe("user-2");
+  });
+
+  test("resolves badge owner", async () => {
+    const supabase = createMockSupabase();
+    supabase._chain.single.mockResolvedValue({ data: { user_id: "user-3" } });
+
+    const result = await resolveActivityOwner(supabase, "badge", "badge-id");
+    expect(supabase.from).toHaveBeenCalledWith("user_badges");
+    expect(result).toBe("user-3");
+  });
+
+  test("resolves border owner", async () => {
+    const supabase = createMockSupabase();
+    supabase._chain.single.mockResolvedValue({ data: { user_id: "user-4" } });
+
+    const result = await resolveActivityOwner(supabase, "border", "border-id");
+    expect(supabase.from).toHaveBeenCalledWith("user_avatar_borders");
+    expect(result).toBe("user-4");
+  });
+
+  test("resolves review owner", async () => {
+    const supabase = createMockSupabase();
+    supabase._chain.single.mockResolvedValue({ data: { user_id: "user-5" } });
+
+    const result = await resolveActivityOwner(supabase, "review", "review-id");
+    expect(supabase.from).toHaveBeenCalledWith("event_reviews");
+    expect(result).toBe("user-5");
+  });
+
+  test("returns null when no data found", async () => {
+    const supabase = createMockSupabase();
+    supabase._chain.single.mockResolvedValue({ data: null });
+
+    const result = await resolveActivityOwner(supabase, "booking", "missing-id");
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Added unit tests for **reserved usernames** (`isReservedUsername` — case insensitivity, trimming, route collisions)
- Added unit tests for **activity owner resolution** (all 5 activity types including `review`, null handling)
- Added unit tests for **feed types** (verify `review` in ActivityType, FeedItem review fields, EMOJI_ICON)
- Updated **CLAUDE.md Testing section** with conventions: test location, Supabase mock pattern, what to test vs not test, the rule that every new feature must include tests

## Test plan
- [x] `pnpm test` — all 74 tests pass (11 files)
- [x] `pnpm typecheck` — no new errors
- [x] `pnpm lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)