### PR TITLE
fix: scope onboarding quiz modal to homepage only

### DIFF
--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -290,7 +290,7 @@ export default function ClientShell({
           onLogout={() => void handleLogout()}
         />
 
-        {!user && <OnboardingQuizModal featureFlags={featureFlags} />}
+        {!user && pathname === "/" && <OnboardingQuizModal featureFlags={featureFlags} />}
         <ChatBubble />
         <InstallPrompt />
         {showDebugPanel && user && (


### PR DESCRIPTION
## Summary
- The `OnboardingQuizModal` was rendering on every page for unauthenticated users, blocking interactions (notably the Sign In button on `/login`)
- Now only renders when `pathname === "/"` — the homepage, where it belongs

## Test plan
- [ ] Visit `/login` as unauthenticated user — no quiz modal overlay
- [ ] Visit `/` as unauthenticated user — quiz modal still appears
- [ ] Visit `/events` as unauthenticated user — no quiz modal overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)