### PR TITLE
ci: run E2E tests on staging pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder"
 
   e2e:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     runs-on: ubuntu-latest
     needs: ci
 


### PR DESCRIPTION
## Summary
- E2E tests previously only ran on pushes to `main`
- Added `staging` to the E2E job condition so tests run on both `main` and `staging` pushes
- Ensures E2E coverage before promoting staging to main

## Test plan
- [ ] Verify CI config is valid by checking workflow runs
- [ ] Push to staging and confirm E2E job triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)