### PR TITLE
ci: seed staging database before E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Seed staging database
+        run: pnpm seed --yes
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 


### PR DESCRIPTION
## Summary
- E2E tests fail because test accounts (`organizer1@test.eventtara.com`, `participant1@test.eventtara.com`) don't exist in the staging Supabase
- Added a `pnpm seed --yes` step before Playwright runs, using the staging service role key
- The seed script is idempotent — it cleans and recreates test data each run

## Required Action
Add the `STAGING_SUPABASE_SERVICE_ROLE_KEY` GitHub secret:
1. Go to **Settings > Secrets and variables > Actions**
2. Add `STAGING_SUPABASE_SERVICE_ROLE_KEY` with the service role key from the **staging** Supabase project (found in Project Settings > API)

## Test plan
- [ ] Add `STAGING_SUPABASE_SERVICE_ROLE_KEY` secret
- [ ] Merge this PR and verify E2E job seeds successfully
- [ ] Confirm E2E auth setup passes (login redirects away from `/login`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)