### PR TITLE
feat: LangGraph.js ReAct agent for Coco chat assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@langchain/anthropic": "^1.3.22",
+    "@langchain/core": "^1.1.31",
+    "@langchain/langgraph": "^1.2.1",
     "@mapbox/polyline": "^1.2.1",
     "@serwist/next": "^9.5.6",
     "@supabase/ssr": "^0.8.0",
@@ -66,7 +69,8 @@
     "resend": "^6.9.2",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.4.1",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,15 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@langchain/anthropic':
+        specifier: ^1.3.22
+        version: 1.3.22(@langchain/core@1.1.31)
+      '@langchain/core':
+        specifier: ^1.1.31
+        version: 1.1.31
+      '@langchain/langgraph':
+        specifier: ^1.2.1
+        version: 1.2.1(@langchain/core@1.1.31)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@mapbox/polyline':
         specifier: ^1.2.1
         version: 1.2.1
@@ -101,6 +110,9 @@ importers:
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -187,6 +199,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@anthropic-ai/sdk@0.74.0':
+    resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@anthropic-ai/sdk@0.77.0':
     resolution: {integrity: sha512-TivlT6nfidz3sOyMF72T2x5AkmHrpT7JgL2e/0HNdh7b24v7JC8cR+rCY/42jA68xIsjmiGQ5IKMsH9feEKh3A==}
     hasBin: true
@@ -207,6 +228,9 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -598,6 +622,47 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@langchain/anthropic@1.3.22':
+    resolution: {integrity: sha512-P/XpLzZlaCU7qba+cgHIO2IKk9EeJwA1OLUJh9+iSRr0peLiZ1ssZeBPNLjBU28MuSDvDtUJt1fFYUYGD4Km1g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.30
+
+  '@langchain/core@1.1.31':
+    resolution: {integrity: sha512-FxsgIUONjKaRpjx59sISgmb0OMCbAetPGyhzjGa2kX0y1f8LZ5xm9VB2db7W9HYWyLvzRWcMA51Uu4OSTJmtZQ==}
+    engines: {node: '>=20'}
+
+  '@langchain/langgraph-checkpoint@1.0.0':
+    resolution: {integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.0.1
+
+  '@langchain/langgraph-sdk@1.6.5':
+    resolution: {integrity: sha512-JjprmbhgCnoNJ9DUKcvrEU+C9FfKsNGyT3ooqWxAY5Cx2qofhXmDJOpTCqqbxfDHPKG0RjTs5HgVK3WW5M6Big==}
+    peerDependencies:
+      '@langchain/core': ^1.1.16
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@langchain/langgraph@1.2.1':
+    resolution: {integrity: sha512-OeLMejye1DZeZBPnurus2bqvjRi+pyrqfAXX77hYdUqKeQ3hAG7pLG04xdrvMs0pl/F57ZtwywqoE2oVqcI6JA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.16
+      zod: ^3.25.32 || ^4.2.0
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
 
   '@mapbox/polyline@1.2.1':
     resolution: {integrity: sha512-sn0V18O3OzW4RCcPoUIVDWvEGQaBNH9a0y5lgqrf5hUycyw1CzrhEoxV5irzrMNXKCkw1xRsZXcaVbsVZggHXA==}
@@ -1099,6 +1164,9 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -1142,6 +1210,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
@@ -1372,6 +1443,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1475,6 +1550,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -1546,6 +1624,10 @@ packages:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
 
@@ -1615,6 +1697,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  console-table-printer@2.15.0:
+    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -1954,6 +2039,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -2306,6 +2394,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.1:
+    resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
+    engines: {node: '>=16'}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -2379,6 +2471,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2434,6 +2529,23 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  langsmith@0.5.9:
+    resolution: {integrity: sha512-mT88HlYTz7IZzVJP/OM7D6PAR3kzcbPGjYDJpx64ua9WiJXFqQx6YKewxIIxkVSZCb9I/9TiYvPYfZ4rawOdEg==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -2580,6 +2692,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -2709,6 +2825,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -2724,6 +2844,26 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-queue@9.1.0:
+    resolution: {integrity: sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==}
+    engines: {node: '>=20'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3175,6 +3315,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -3468,6 +3611,14 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
   uzip@0.20201231.0:
     resolution: {integrity: sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==}
 
@@ -3649,6 +3800,12 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
   '@anthropic-ai/sdk@0.77.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -3664,6 +3821,8 @@ snapshots:
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3962,6 +4121,59 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@langchain/anthropic@1.3.22(@langchain/core@1.1.31)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.74.0(zod@4.3.6)
+      '@langchain/core': 1.1.31
+      zod: 4.3.6
+
+  '@langchain/core@1.1.31':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.5.9
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      uuid: 11.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.31)':
+    dependencies:
+      '@langchain/core': 1.1.31
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@1.6.5(@langchain/core@1.1.31)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.0
+      p-retry: 7.1.1
+      uuid: 13.0.0
+    optionalDependencies:
+      '@langchain/core': 1.1.31
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@langchain/langgraph@1.2.1(@langchain/core@1.1.31)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+    dependencies:
+      '@langchain/core': 1.1.31
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.31)
+      '@langchain/langgraph-sdk': 1.6.5(@langchain/core@1.1.31)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@mapbox/polyline@1.2.1':
     dependencies:
@@ -4427,6 +4639,8 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/json5@0.0.29': {}
 
   '@types/leaflet@1.9.21':
@@ -4467,6 +4681,8 @@ snapshots:
   '@types/trusted-types@2.0.7': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@types/web-push@3.6.4':
     dependencies:
@@ -4698,6 +4914,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -4820,6 +5038,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   binary-extensions@2.3.0: {}
@@ -4890,6 +5110,8 @@ snapshots:
 
   camelcase@5.3.1: {}
 
+  camelcase@6.3.0: {}
+
   caniuse-lite@1.0.30001770: {}
 
   canvas-confetti@1.9.4: {}
@@ -4949,6 +5171,10 @@ snapshots:
   common-tags@1.8.2: {}
 
   concat-map@0.0.1: {}
+
+  console-table-printer@2.15.0:
+    dependencies:
+      simple-wcswidth: 1.1.2
 
   cookie@1.1.1: {}
 
@@ -5469,6 +5695,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   execa@8.0.1:
@@ -5821,6 +6049,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.3.1: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -5894,6 +6124,10 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -5946,6 +6180,15 @@ snapshots:
   kind-of@6.0.3: {}
 
   kolorist@1.8.0: {}
+
+  langsmith@0.5.9:
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 5.6.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.4
+      uuid: 10.0.0
 
   language-subtag-registry@0.3.23: {}
 
@@ -6103,6 +6346,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mustache@4.2.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -6253,6 +6498,8 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-finally@1.0.0: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -6268,6 +6515,26 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-queue@9.1.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
 
@@ -6795,6 +7062,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-wcswidth@1.1.2: {}
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -7157,6 +7426,10 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
+
+  uuid@13.0.0: {}
 
   uzip@0.20201231.0: {}
 

--- a/src/app/(frontend)/api/chat/route.ts
+++ b/src/app/(frontend)/api/chat/route.ts
@@ -1,18 +1,33 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { type StreamEvent } from "@langchain/core/tracers/log_stream";
+import { MemorySaver } from "@langchain/langgraph";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 
-import { buildSearchSystemPrompt, buildSuggestionPrompt } from "@/lib/ai/search-prompt";
-import { type ParsedSearchParams } from "@/lib/ai/search-prompt";
-import { ACTIVITY_TYPES } from "@/lib/constants/activity-types";
+import { createCocoAgent } from "@/lib/ai/agent";
+import { executeEventSearch } from "@/lib/ai/agent/event-query-builder";
+import { type SSEEvent } from "@/lib/ai/agent/types";
+import {
+  type ParsedSearchParams,
+  buildSearchSystemPrompt,
+  buildSuggestionPrompt,
+} from "@/lib/ai/search-prompt";
+import { isChatAgentV2Enabled } from "@/lib/cms/cached";
 import { createClient } from "@/lib/supabase/server";
-import type { Database, Json } from "@/lib/supabase/types";
-import { haversineDistance } from "@/lib/utils/geo";
-
-type EventType = Database["public"]["Tables"]["events"]["Row"]["type"];
+import type { Json } from "@/lib/supabase/types";
 
 // Hard daily cap per user/IP to prevent abuse (session limit is enforced client-side)
 const DAILY_HARD_CAP = 30;
+
+// Vercel serverless function timeout
+export const maxDuration = 30;
+
+// Shared checkpointer for in-session memory across requests (reset on cold start)
+const agentCheckpointer = new MemorySaver();
+
+function formatSSE(event: SSEEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
 
 export async function POST(request: Request) {
   const supabase = await createClient();
@@ -28,6 +43,7 @@ export async function POST(request: Request) {
   // Parse request body
   let message: string;
   let userLocation: { lat: number; lng: number } | undefined;
+  let threadId: string | undefined;
   try {
     const body = await request.json();
     message = body.message;
@@ -37,15 +53,17 @@ export async function POST(request: Request) {
     if (message.length > 500) {
       return NextResponse.json({ error: "Message too long (max 500 characters)" }, { status: 400 });
     }
-    // Optional geolocation from the client
     if (typeof body.lat === "number" && typeof body.lng === "number") {
       userLocation = { lat: body.lat, lng: body.lng };
+    }
+    if (typeof body.threadId === "string") {
+      threadId = body.threadId;
     }
   } catch {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  // Hard daily cap check (abuse prevention — session limit is client-side)
+  // Hard daily cap check
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const todayISO = todayStart.toISOString();
@@ -70,11 +88,160 @@ export async function POST(request: Request) {
     );
   }
 
-  // Call Claude Haiku
   const apiKey = process.env.ANTHROPIC_CHAT_API_KEY;
   if (!apiKey) {
     return NextResponse.json({ error: "Chat service not configured" }, { status: 503 });
   }
+
+  // Feature flag: LangGraph agent v2 vs legacy
+  const useAgentV2 = threadId && (await isChatAgentV2Enabled());
+
+  if (useAgentV2) {
+    return handleAgentRequest({
+      message: message.trim(),
+      threadId: threadId!,
+      userId: user?.id ?? null,
+      userName: user?.user_metadata?.full_name ?? null,
+      userLocation: userLocation ?? null,
+      supabase,
+      ip,
+    });
+  }
+
+  return handleLegacyRequest({
+    message: message.trim(),
+    userLocation,
+    supabase,
+    userId: user?.id ?? null,
+    ip,
+    apiKey,
+  });
+}
+
+// ── LangGraph Agent Handler ─────────────────────────────────────────
+
+interface AgentRequestParams {
+  message: string;
+  threadId: string;
+  userId: string | null;
+  userName: string | null;
+  userLocation: { lat: number; lng: number } | null;
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  ip: string;
+}
+
+async function handleAgentRequest(params: AgentRequestParams) {
+  const { message, threadId, userId, userName, userLocation, supabase, ip } = params;
+
+  const agent = createCocoAgent({
+    ctx: { supabase, userId, userName, userLocation },
+    checkpointer: agentCheckpointer,
+  });
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        const eventStream = agent.streamEvents(
+          { messages: [{ role: "user", content: message }] },
+          {
+            configurable: { thread_id: threadId },
+            recursionLimit: 8,
+            version: "v2",
+          },
+        );
+
+        for await (const event of eventStream as AsyncIterable<StreamEvent>) {
+          switch (event.event) {
+            case "on_chat_model_stream": {
+              const chunk = event.data?.chunk;
+              if (chunk?.content && typeof chunk.content === "string") {
+                controller.enqueue(
+                  encoder.encode(formatSSE({ type: "token", content: chunk.content })),
+                );
+              }
+              break;
+            }
+            case "on_tool_start": {
+              controller.enqueue(
+                encoder.encode(formatSSE({ type: "tool_start", name: event.name ?? "unknown" })),
+              );
+              break;
+            }
+            case "on_tool_end": {
+              let data: unknown = null;
+              try {
+                data =
+                  typeof event.data?.output === "string"
+                    ? JSON.parse(event.data.output)
+                    : event.data?.output;
+              } catch {
+                data = event.data?.output;
+              }
+              controller.enqueue(
+                encoder.encode(
+                  formatSSE({ type: "tool_result", name: event.name ?? "unknown", data }),
+                ),
+              );
+              break;
+            }
+          }
+        }
+
+        controller.enqueue(encoder.encode(formatSSE({ type: "done" })));
+      } catch (error) {
+        console.error("[chat] Agent stream error:", error);
+        controller.enqueue(
+          encoder.encode(
+            formatSSE({
+              type: "error",
+              message: "Sorry, something went wrong. Please try again.",
+            }),
+          ),
+        );
+      } finally {
+        // Log query for analytics
+        await supabase
+          .from("chat_queries")
+          .insert({
+            user_id: userId,
+            ip_address: userId ? null : ip,
+            query: message,
+            parsed_params: { agent: "v2", threadId } as unknown as Json,
+            result_count: 0,
+          })
+          .then(({ error }) => {
+            if (error) console.error("[chat] Failed to log query:", error.message);
+          });
+
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+// ── Legacy Handler (unchanged behavior) ─────────────────────────────
+
+interface LegacyRequestParams {
+  message: string;
+  userLocation?: { lat: number; lng: number };
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  userId: string | null;
+  ip: string;
+  apiKey: string;
+}
+
+async function handleLegacyRequest(params: LegacyRequestParams) {
+  const { message, userLocation, supabase, userId, ip, apiKey } = params;
 
   const anthropic = new Anthropic({ apiKey });
 
@@ -84,11 +251,10 @@ export async function POST(request: Request) {
       model: "claude-haiku-4-5-20251001",
       max_tokens: 300,
       system: buildSearchSystemPrompt(userLocation),
-      messages: [{ role: "user", content: message.trim() }],
+      messages: [{ role: "user", content: message }],
     });
 
     const text = completion.content[0].type === "text" ? completion.content[0].text : "";
-    // Strip markdown code fences if Haiku wraps the JSON
     const cleaned = text
       .replace(/^```(?:json)?\s*\n?/i, "")
       .replace(/\n?```\s*$/i, "")
@@ -107,236 +273,27 @@ export async function POST(request: Request) {
     );
   }
 
-  // Build event query using same patterns as /api/events
-  const today = new Date().toISOString().split("T")[0];
-
-  let countQ = supabase
-    .from("events")
-    .select("id", { count: "exact", head: true })
-    .in("status", ["published", "completed"] as const);
-
-  let dataQ = supabase
-    .from("events")
-    .select("id, title, type, date, location, price, cover_image_url, coordinates")
-    .in("status", ["published", "completed"] as const);
-
-  // Apply parsed filters
-  if (parsed.type && (ACTIVITY_TYPES as readonly string[]).includes(parsed.type)) {
-    countQ = countQ.eq("type", parsed.type);
-    dataQ = dataQ.eq("type", parsed.type);
-  }
-
-  if (parsed.search) {
-    const pattern = parsed.search.trim().replaceAll(/\s+/g, "%");
-
-    // Also match club names (same pattern as /api/events)
-    const { data: matchingClubs } = await supabase
-      .from("clubs")
-      .select("id")
-      .ilike("name", `%${pattern}%`);
-    const clubIds = matchingClubs?.map((c) => c.id) ?? [];
-
-    // Also match guide names → get their linked event IDs
-    const { data: matchingGuides } = await supabase
-      .from("guides")
-      .select("id")
-      .ilike("full_name", `%${pattern}%`);
-    let guideEventIds: string[] = [];
-    if (matchingGuides && matchingGuides.length > 0) {
-      const guideIds = matchingGuides.map((g) => g.id);
-      const { data: links } = await supabase
-        .from("event_guides")
-        .select("event_id")
-        .in("guide_id", guideIds);
-      guideEventIds = links?.map((l) => l.event_id) ?? [];
-    }
-
-    let filter = `title.ilike.%${pattern}%,location.ilike.%${pattern}%`;
-    if (clubIds.length > 0) {
-      filter += `,club_id.in.(${clubIds.join(",")})`;
-    }
-    if (guideEventIds.length > 0) {
-      filter += `,id.in.(${guideEventIds.join(",")})`;
-    }
-    countQ = countQ.or(filter);
-    dataQ = dataQ.or(filter);
-  }
-
-  if (parsed.duration === "single") {
-    countQ = countQ.is("end_date", null);
-    dataQ = dataQ.is("end_date", null);
-  } else if (parsed.duration === "multi") {
-    countQ = countQ.not("end_date", "is", null);
-    dataQ = dataQ.not("end_date", "is", null);
-  }
-
-  // Distance filter: query event_distances table for matching distance
-  if (parsed.distance) {
-    const { data: distanceRows } = await supabase
-      .from("event_distances")
-      .select("event_id")
-      .eq("distance_km", parsed.distance);
-    const distanceEventIds = distanceRows?.map((d) => d.event_id) ?? [];
-    if (distanceEventIds.length === 0) {
-      // No events match this distance — return empty results early
-      const emptyFilterParts: string[] = [];
-      if (parsed.search) emptyFilterParts.push(`search=${encodeURIComponent(parsed.search)}`);
-      if (parsed.type) emptyFilterParts.push(`type=${parsed.type}`);
-      if (parsed.distance) emptyFilterParts.push(`distance=${parsed.distance}`);
-      if (parsed.difficulty) emptyFilterParts.push(`difficulty=${parsed.difficulty}`);
-      const emptyFilterUrl = `/events${emptyFilterParts.length > 0 ? `?${emptyFilterParts.join("&")}` : ""}`;
-
-      // Log query even for empty distance results
-      await supabase.from("chat_queries").insert({
-        user_id: user?.id ?? null,
-        ip_address: user ? null : ip,
-        query: message.trim(),
-        parsed_params: parsed as unknown as Json,
-        result_count: 0,
-      });
-
-      const searchTerm = parsed.search ?? message.trim();
-      return NextResponse.json({
-        reply: `Sorry, but there are no results for "${searchTerm}". Try a different search or browse all events!`,
-        events: [],
-        totalCount: 0,
-        filterUrl: emptyFilterUrl,
-      });
-    }
-    countQ = countQ.in("id", distanceEventIds);
-    dataQ = dataQ.in("id", distanceEventIds);
-  }
-
-  // Difficulty filter: range-based (e.g. "1-4", "5-7", "8-9")
-  if (parsed.difficulty) {
-    const [minStr, maxStr] = parsed.difficulty.split("-");
-    const min = Number.parseInt(minStr, 10);
-    const max = Number.parseInt(maxStr, 10);
-    if (!Number.isNaN(min) && !Number.isNaN(max)) {
-      countQ = countQ
-        .not("difficulty_level", "is", null)
-        .gte("difficulty_level", min)
-        .lte("difficulty_level", max);
-      dataQ = dataQ
-        .not("difficulty_level", "is", null)
-        .gte("difficulty_level", min)
-        .lte("difficulty_level", max);
-    }
-  }
-
-  if (parsed.dateFrom) {
-    countQ = countQ.gte("date", parsed.dateFrom);
-    dataQ = dataQ.gte("date", parsed.dateFrom);
-  }
-
-  if (parsed.dateTo) {
-    countQ = countQ.lte("date", `${parsed.dateTo}T23:59:59`);
-    dataQ = dataQ.lte("date", `${parsed.dateTo}T23:59:59`);
-  }
-
-  if (parsed.when) {
-    switch (parsed.when) {
-      case "upcoming": {
-        countQ = countQ.gt("date", today);
-        dataQ = dataQ.gt("date", today);
-        break;
-      }
-      case "now": {
-        countQ = countQ.gte("date", today).lte("date", `${today}T23:59:59`);
-        dataQ = dataQ.gte("date", today).lte("date", `${today}T23:59:59`);
-        break;
-      }
-      case "past": {
-        countQ = countQ.lt("date", today);
-        dataQ = dataQ.lt("date", today);
-        break;
-      }
-    }
-  }
-
-  // When sorting by distance, fetch more results to sort client-side then take top 3
-  const fetchLimit = userLocation && parsed.nearMe ? 20 : 3;
-  dataQ = dataQ.order("date", { ascending: true }).limit(fetchLimit);
-
-  const [{ count: totalCount }, { data: events }] = await Promise.all([countQ, dataQ]);
-
-  interface ChatEvent {
-    id: string;
-    title: string;
-    type: EventType;
-    date: string;
-    location: string;
-    price: number;
-    cover_image_url: string | null;
-    coordinates: { lat: number; lng: number } | null;
-  }
-
-  const allEvents = (events ?? []) as ChatEvent[];
-
-  // Sort by distance from user's location when nearMe is requested
-  const topEvents: ChatEvent[] =
-    userLocation && parsed.nearMe && allEvents.length > 0
-      ? [...allEvents]
-          .sort((a, b) => {
-            const distA = a.coordinates
-              ? haversineDistance(
-                  userLocation.lat,
-                  userLocation.lng,
-                  a.coordinates.lat,
-                  a.coordinates.lng,
-                )
-              : Infinity;
-            const distB = b.coordinates
-              ? haversineDistance(
-                  userLocation.lat,
-                  userLocation.lng,
-                  b.coordinates.lat,
-                  b.coordinates.lng,
-                )
-              : Infinity;
-            return distA - distB;
-          })
-          .slice(0, 3)
-      : allEvents.slice(0, 3);
-
-  const miniEvents = topEvents.map((e) => ({
-    id: e.id,
-    title: e.title,
-    type: e.type,
-    date: e.date,
-    location: e.location,
-    price: e.price,
-    cover_image_url: e.cover_image_url,
-  }));
-
-  const count = totalCount ?? 0;
-
-  // Build filter URL for "View all results"
-  const filterParts: string[] = [];
-  if (parsed.search) filterParts.push(`search=${encodeURIComponent(parsed.search)}`);
-  if (parsed.type) filterParts.push(`type=${parsed.type}`);
-  if (parsed.dateFrom) filterParts.push(`from=${parsed.dateFrom}`);
-  if (parsed.dateTo) filterParts.push(`to=${parsed.dateTo}`);
-  if (parsed.when) filterParts.push(`when=${parsed.when}`);
-  if (parsed.distance) filterParts.push(`distance=${parsed.distance}`);
-  if (parsed.difficulty) filterParts.push(`difficulty=${parsed.difficulty}`);
-  const filterUrl = `/events${filterParts.length > 0 ? `?${filterParts.join("&")}` : ""}`;
+  const result = await executeEventSearch({
+    supabase,
+    parsed,
+    userLocation,
+  });
 
   // Log query for rate limiting + analytics
   const { error: insertErr } = await supabase.from("chat_queries").insert({
-    user_id: user?.id ?? null,
-    ip_address: user ? null : ip,
-    query: message.trim(),
+    user_id: userId,
+    ip_address: userId ? null : ip,
+    query: message,
     parsed_params: parsed as unknown as Json,
-    result_count: count,
+    result_count: result.totalCount,
   });
   if (insertErr) {
     console.error("[chat] Failed to log query:", insertErr.message);
   }
 
-  // When no results found, run fallback query and suggest nearest events
-  if (count === 0) {
-    // Fallback: keep type + search, drop date/distance/difficulty, find nearest upcoming
+  // When no results found, run fallback query
+  if (result.totalCount === 0) {
+    const today = new Date().toISOString().split("T")[0];
     let fallbackQ = supabase
       .from("events")
       .select("id, title, type, date, location, price, cover_image_url")
@@ -355,12 +312,11 @@ export async function POST(request: Request) {
     const { data: fallbackEvents } = await fallbackQ;
 
     if (fallbackEvents && fallbackEvents.length > 0) {
-      // Second Claude call to generate a natural suggestion
       try {
         const suggestionCompletion = await anthropic.messages.create({
           model: "claude-haiku-4-5-20251001",
           max_tokens: 200,
-          system: buildSuggestionPrompt(message.trim(), parsed.type, fallbackEvents),
+          system: buildSuggestionPrompt(message, parsed.type, fallbackEvents),
           messages: [{ role: "user", content: "Suggest the nearest events." }],
         });
 
@@ -384,7 +340,6 @@ export async function POST(request: Request) {
           cover_image_url: e.cover_image_url,
         }));
 
-        // Build broader filter URL for "View all results"
         const fallbackFilterParts: string[] = [];
         if (parsed.type) fallbackFilterParts.push(`type=${parsed.type}`);
         if (parsed.search) fallbackFilterParts.push(`search=${encodeURIComponent(parsed.search)}`);
@@ -398,24 +353,23 @@ export async function POST(request: Request) {
           filterUrl: fallbackFilterUrl,
         });
       } catch {
-        // If suggestion call fails, fall through to generic empty response
+        // Fall through to generic empty response
       }
     }
 
-    // No fallback events found either, or suggestion call failed
-    const searchTerm = parsed.search ?? message.trim();
+    const searchTerm = parsed.search ?? message;
     return NextResponse.json({
       reply: `Sorry, but there are no results for "${searchTerm}". Try a different search or browse all events!`,
       events: [],
       totalCount: 0,
-      filterUrl,
+      filterUrl: result.filterUrl,
     });
   }
 
   return NextResponse.json({
     reply: parsed.reply,
-    events: miniEvents,
-    totalCount: count,
-    filterUrl,
+    events: result.events,
+    totalCount: result.totalCount,
+    filterUrl: result.filterUrl,
   });
 }

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -3,12 +3,24 @@ import Link from "next/link";
 import ChatEventCard from "./ChatEventCard";
 import type { ChatMessage as ChatMessageType } from "./types";
 
+const TOOL_LABELS: Record<string, string> = {
+  searchEvents: "Searching events...",
+  getEventDetails: "Getting event details...",
+  getEventRoute: "Checking route info...",
+  getUserBookings: "Checking your bookings...",
+  getUserBadges: "Looking up badges...",
+  getClubInfo: "Getting club info...",
+  getUserClubs: "Checking your clubs...",
+  getLeaderboard: "Loading leaderboard...",
+};
+
 interface ChatMessageProps {
   message: ChatMessageType;
 }
 
 export default function ChatMessage({ message }: ChatMessageProps) {
   const isUser = message.role === "user";
+  const activeTools = message.toolCalls?.filter((t) => t.status === "running") ?? [];
 
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
@@ -19,7 +31,27 @@ export default function ChatMessage({ message }: ChatMessageProps) {
             : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200 rounded-bl-md"
         }`}
       >
-        <p className="whitespace-pre-wrap">{message.content}</p>
+        {/* Tool activity indicators */}
+        {activeTools.length > 0 && (
+          <div className="mb-1.5 space-y-0.5">
+            {activeTools.map((tool) => (
+              <div
+                key={tool.name}
+                className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+              >
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-lime-500 animate-pulse" />
+                {TOOL_LABELS[tool.name] ?? `Running ${tool.name}...`}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <p className="whitespace-pre-wrap">
+          {message.content}
+          {message.isStreaming && (
+            <span className="inline-block w-1.5 h-4 ml-0.5 bg-gray-600 dark:bg-gray-300 animate-pulse align-text-bottom" />
+          )}
+        </p>
 
         {message.events && message.events.length > 0 && (
           <div className="mt-2 space-y-2">

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -7,7 +7,7 @@ import { CloseIcon, SendIcon } from "@/components/icons";
 import { type Corner } from "@/lib/hooks/useDraggable";
 
 import ChatMessage from "./ChatMessage";
-import type { ChatMessage as ChatMessageType, ChatResponse } from "./types";
+import type { ChatMessage as ChatMessageType, ChatResponse, ToolCallInfo } from "./types";
 
 const DAILY_LIMIT = 5;
 const STORAGE_KEY = "eventtara_chat_queries";
@@ -93,6 +93,7 @@ export default function ChatPanel({
   const inputRef = useRef<HTMLInputElement>(null);
   const locationRef = useRef<{ lat: number; lng: number } | null>(null);
   const hasAutoSuggested = useRef(false);
+  const threadIdRef = useRef<string>(crypto.randomUUID());
 
   // Request geolocation once on first open
   useEffect(() => {
@@ -135,11 +136,9 @@ export default function ChatPanel({
   // Auto-suggest nearby events on first open when location is available
   useEffect(() => {
     if (!open || hasAutoSuggested.current || loading) return;
-    // Wait a bit for geolocation to resolve
     const timer = setTimeout(() => {
       if (!locationRef.current || hasAutoSuggested.current || remaining <= 0) return;
       hasAutoSuggested.current = true;
-      // Fire a "nearby events" search automatically
       void (async () => {
         setLoading(true);
         try {
@@ -180,6 +179,112 @@ export default function ChatPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally run once on first open
   }, [open]);
 
+  /** Consume an SSE stream from the agent v2 endpoint */
+  async function consumeStream(response: Response) {
+    const reader = response.body?.getReader();
+    if (!reader) return;
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const msgIndex = messages.length; // index of the streaming message (will be appended)
+    let content = "";
+    const toolCalls: ToolCallInfo[] = [];
+
+    // Add empty streaming message
+    setMessages((prev) => [
+      ...prev,
+      { role: "assistant", content: "", isStreaming: true, toolCalls: [] },
+    ]);
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const jsonStr = line.slice(6).trim();
+          if (!jsonStr) continue;
+
+          try {
+            const event: {
+              type: string;
+              content?: string;
+              name?: string;
+              data?: unknown;
+              message?: string;
+            } = JSON.parse(jsonStr);
+
+            const updateStreaming = (overrides?: Partial<ChatMessageType>) => {
+              setMessages((prev) => {
+                const updated = [...prev];
+                updated[msgIndex] = {
+                  ...updated[msgIndex],
+                  content,
+                  isStreaming: true,
+                  toolCalls: [...toolCalls],
+                  ...overrides,
+                };
+                return updated;
+              });
+            };
+
+            switch (event.type) {
+              case "token": {
+                content += event.content ?? "";
+                updateStreaming();
+                break;
+              }
+
+              case "tool_start": {
+                toolCalls.push({ name: event.name ?? "unknown", status: "running" });
+                updateStreaming();
+                break;
+              }
+
+              case "tool_result": {
+                const idx = toolCalls.findIndex(
+                  (t) => t.name === event.name && t.status === "running",
+                );
+                if (idx !== -1) {
+                  toolCalls[idx] = { ...toolCalls[idx], status: "done" };
+                }
+                updateStreaming();
+                break;
+              }
+
+              case "done": {
+                updateStreaming({ isStreaming: false, toolCalls: undefined });
+                break;
+              }
+
+              case "error": {
+                setMessages((prev) => {
+                  const updated = [...prev];
+                  updated[msgIndex] = {
+                    role: "assistant",
+                    content: event.message || "Something went wrong. Please try again.",
+                    isStreaming: false,
+                  };
+                  return updated;
+                });
+                break;
+              }
+            }
+          } catch {
+            // Skip malformed SSE lines
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   const handleSend = async () => {
     const trimmed = input.trim();
     if (!trimmed || loading) return;
@@ -190,7 +295,10 @@ export default function ChatPanel({
     setLoading(true);
 
     try {
-      const payload: Record<string, unknown> = { message: trimmed };
+      const payload: Record<string, unknown> = {
+        message: trimmed,
+        threadId: threadIdRef.current,
+      };
       if (locationRef.current) {
         payload.lat = locationRef.current.lat;
         payload.lng = locationRef.current.lng;
@@ -201,9 +309,10 @@ export default function ChatPanel({
         body: JSON.stringify(payload),
       });
 
-      const data: ChatResponse = await res.json();
+      const contentType = res.headers.get("Content-Type") ?? "";
 
       if (res.status === 429) {
+        const data: ChatResponse = await res.json();
         setMessages((prev) => [
           ...prev,
           {
@@ -217,22 +326,31 @@ export default function ChatPanel({
         return;
       }
 
-      if (data.error && res.status !== 200) {
-        setMessages((prev) => [
-          ...prev,
-          { role: "assistant", content: "Something went wrong. Please try again." },
-        ]);
-        return;
+      // SSE streaming path (agent v2)
+      if (contentType.includes("text/event-stream")) {
+        await consumeStream(res);
+      } else {
+        // Legacy JSON path
+        const data: ChatResponse = await res.json();
+
+        if (data.error && res.status !== 200) {
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", content: "Something went wrong. Please try again." },
+          ]);
+          return;
+        }
+
+        const assistantMessage: ChatMessageType = {
+          role: "assistant",
+          content: data.reply,
+          events: data.events,
+          totalCount: data.totalCount,
+          filterUrl: data.filterUrl,
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
       }
 
-      const assistantMessage: ChatMessageType = {
-        role: "assistant",
-        content: data.reply,
-        events: data.events,
-        totalCount: data.totalCount,
-        filterUrl: data.filterUrl,
-      };
-      setMessages((prev) => [...prev, assistantMessage]);
       if (!unlimitedChat) {
         incrementUsed();
         setRemaining(DAILY_LIMIT - getUsedToday());
@@ -263,15 +381,8 @@ export default function ChatPanel({
   const viewportOffset = keyboard?.viewportOffset ?? 0;
   const keyboardOpen = kbHeight > 0;
 
-  // On iOS, when the keyboard opens the browser scrolls the page up.
-  // Fixed elements stay relative to the layout viewport, so bottom-based
-  // positioning breaks. Instead, use top-based positioning calculated from
-  // the visual viewport: place the panel so its bottom edge sits at the
-  // top of the keyboard (bottom of the visible area).
   const keyboardStyle: React.CSSProperties | undefined = keyboardOpen
     ? {
-        // Bottom of visible area = viewportOffset + visualViewport.height
-        // = viewportOffset + (window.innerHeight - kbHeight)
         top: `${viewportOffset + (window.innerHeight - kbHeight) - PANEL_MAX_HEIGHT}px`,
         bottom: "auto",
         height: `${PANEL_MAX_HEIGHT}px`,
@@ -337,7 +448,7 @@ export default function ChatPanel({
             </div>
           ))}
 
-          {loading && (
+          {loading && !messages.some((m) => m.isStreaming) && (
             <div className="animate-chat-message-in flex justify-start">
               <div className="rounded-2xl rounded-bl-md bg-gray-100 px-4 py-2.5 dark:bg-gray-700">
                 <div className="flex gap-1">

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -8,12 +8,19 @@ export interface MiniEvent {
   cover_image_url: string | null;
 }
 
+export interface ToolCallInfo {
+  name: string;
+  status: "running" | "done";
+}
+
 export interface ChatMessage {
   role: "user" | "assistant";
   content: string;
   events?: MiniEvent[];
   totalCount?: number;
   filterUrl?: string;
+  isStreaming?: boolean;
+  toolCalls?: ToolCallInfo[];
 }
 
 export interface ChatResponse {

--- a/src/components/debug/DebugToolPanel.tsx
+++ b/src/components/debug/DebugToolPanel.tsx
@@ -45,6 +45,7 @@ const FLAG_LABELS: Record<keyof Omit<CmsFeatureFlags, "id">, string> = {
   oauth_strava: "Lock Strava Login",
   oauth_facebook: "Lock Facebook Login",
   onboarding_quiz: "Onboarding Quiz",
+  chat_agent_v2: "Chat Agent V2 (LangGraph)",
 };
 
 type FlagKey = keyof Omit<CmsFeatureFlags, "id">;
@@ -65,6 +66,7 @@ const FLAG_KEYS: FlagKey[] = [
   "oauth_strava",
   "oauth_facebook",
   "onboarding_quiz",
+  "chat_agent_v2",
 ];
 
 /* ------------------------------------------------------------------ */

--- a/src/lib/ai/agent/event-query-builder.ts
+++ b/src/lib/ai/agent/event-query-builder.ts
@@ -1,0 +1,229 @@
+import { type ParsedSearchParams } from "@/lib/ai/search-prompt";
+import { ACTIVITY_TYPES } from "@/lib/constants/activity-types";
+import { haversineDistance } from "@/lib/utils/geo";
+
+import { type AgentSupabaseClient, type MiniEventResult } from "./types";
+
+interface EventQueryOptions {
+  supabase: AgentSupabaseClient;
+  parsed: ParsedSearchParams;
+  userLocation?: { lat: number; lng: number } | null;
+}
+
+interface EventQueryResult {
+  events: MiniEventResult[];
+  totalCount: number;
+  filterUrl: string;
+}
+
+/**
+ * Build and execute an event search query from parsed search params.
+ * Extracted from the chat route.ts to be shared between legacy path and searchEvents tool.
+ */
+export async function executeEventSearch({
+  supabase,
+  parsed,
+  userLocation,
+}: EventQueryOptions): Promise<EventQueryResult> {
+  const today = new Date().toISOString().split("T")[0];
+
+  let countQ = supabase
+    .from("events")
+    .select("id", { count: "exact", head: true })
+    .in("status", ["published", "completed"] as const);
+
+  let dataQ = supabase
+    .from("events")
+    .select("id, title, type, date, location, price, cover_image_url, coordinates")
+    .in("status", ["published", "completed"] as const);
+
+  // Activity type filter
+  if (parsed.type && (ACTIVITY_TYPES as readonly string[]).includes(parsed.type)) {
+    countQ = countQ.eq("type", parsed.type);
+    dataQ = dataQ.eq("type", parsed.type);
+  }
+
+  // Text search (title, location, club name, guide name)
+  if (parsed.search) {
+    const pattern = parsed.search.trim().replaceAll(/\s+/g, "%");
+
+    const { data: matchingClubs } = await supabase
+      .from("clubs")
+      .select("id")
+      .ilike("name", `%${pattern}%`);
+    const clubIds = matchingClubs?.map((c) => c.id) ?? [];
+
+    const { data: matchingGuides } = await supabase
+      .from("guides")
+      .select("id")
+      .ilike("full_name", `%${pattern}%`);
+    let guideEventIds: string[] = [];
+    if (matchingGuides && matchingGuides.length > 0) {
+      const guideIds = matchingGuides.map((g) => g.id);
+      const { data: links } = await supabase
+        .from("event_guides")
+        .select("event_id")
+        .in("guide_id", guideIds);
+      guideEventIds = links?.map((l) => l.event_id) ?? [];
+    }
+
+    let filter = `title.ilike.%${pattern}%,location.ilike.%${pattern}%`;
+    if (clubIds.length > 0) {
+      filter += `,club_id.in.(${clubIds.join(",")})`;
+    }
+    if (guideEventIds.length > 0) {
+      filter += `,id.in.(${guideEventIds.join(",")})`;
+    }
+    countQ = countQ.or(filter);
+    dataQ = dataQ.or(filter);
+  }
+
+  // Duration filter
+  if (parsed.duration === "single") {
+    countQ = countQ.is("end_date", null);
+    dataQ = dataQ.is("end_date", null);
+  } else if (parsed.duration === "multi") {
+    countQ = countQ.not("end_date", "is", null);
+    dataQ = dataQ.not("end_date", "is", null);
+  }
+
+  // Distance filter
+  if (parsed.distance) {
+    const { data: distanceRows } = await supabase
+      .from("event_distances")
+      .select("event_id")
+      .eq("distance_km", parsed.distance);
+    const distanceEventIds = distanceRows?.map((d) => d.event_id) ?? [];
+    if (distanceEventIds.length === 0) {
+      return {
+        events: [],
+        totalCount: 0,
+        filterUrl: buildFilterUrl(parsed),
+      };
+    }
+    countQ = countQ.in("id", distanceEventIds);
+    dataQ = dataQ.in("id", distanceEventIds);
+  }
+
+  // Difficulty filter
+  if (parsed.difficulty) {
+    const [minStr, maxStr] = parsed.difficulty.split("-");
+    const min = Number.parseInt(minStr, 10);
+    const max = Number.parseInt(maxStr, 10);
+    if (!Number.isNaN(min) && !Number.isNaN(max)) {
+      countQ = countQ
+        .not("difficulty_level", "is", null)
+        .gte("difficulty_level", min)
+        .lte("difficulty_level", max);
+      dataQ = dataQ
+        .not("difficulty_level", "is", null)
+        .gte("difficulty_level", min)
+        .lte("difficulty_level", max);
+    }
+  }
+
+  // Date filters
+  if (parsed.dateFrom) {
+    countQ = countQ.gte("date", parsed.dateFrom);
+    dataQ = dataQ.gte("date", parsed.dateFrom);
+  }
+  if (parsed.dateTo) {
+    countQ = countQ.lte("date", `${parsed.dateTo}T23:59:59`);
+    dataQ = dataQ.lte("date", `${parsed.dateTo}T23:59:59`);
+  }
+
+  // When filter
+  if (parsed.when) {
+    switch (parsed.when) {
+      case "upcoming": {
+        countQ = countQ.gt("date", today);
+        dataQ = dataQ.gt("date", today);
+        break;
+      }
+      case "now": {
+        countQ = countQ.gte("date", today).lte("date", `${today}T23:59:59`);
+        dataQ = dataQ.gte("date", today).lte("date", `${today}T23:59:59`);
+        break;
+      }
+      case "past": {
+        countQ = countQ.lt("date", today);
+        dataQ = dataQ.lt("date", today);
+        break;
+      }
+    }
+  }
+
+  // Fetch more if sorting by distance
+  const fetchLimit = userLocation && parsed.nearMe ? 20 : 3;
+  dataQ = dataQ.order("date", { ascending: true }).limit(fetchLimit);
+
+  const [{ count: totalCount }, { data: events }] = await Promise.all([countQ, dataQ]);
+
+  interface ChatEvent {
+    id: string;
+    title: string;
+    type: string;
+    date: string;
+    location: string;
+    price: number;
+    cover_image_url: string | null;
+    coordinates: { lat: number; lng: number } | null;
+  }
+
+  const allEvents = (events ?? []) as ChatEvent[];
+
+  // Sort by distance when nearMe is requested
+  const topEvents: ChatEvent[] =
+    userLocation && parsed.nearMe && allEvents.length > 0
+      ? [...allEvents]
+          .sort((a, b) => {
+            const distA = a.coordinates
+              ? haversineDistance(
+                  userLocation.lat,
+                  userLocation.lng,
+                  a.coordinates.lat,
+                  a.coordinates.lng,
+                )
+              : Infinity;
+            const distB = b.coordinates
+              ? haversineDistance(
+                  userLocation.lat,
+                  userLocation.lng,
+                  b.coordinates.lat,
+                  b.coordinates.lng,
+                )
+              : Infinity;
+            return distA - distB;
+          })
+          .slice(0, 3)
+      : allEvents.slice(0, 3);
+
+  const miniEvents: MiniEventResult[] = topEvents.map((e) => ({
+    id: e.id,
+    title: e.title,
+    type: e.type,
+    date: e.date,
+    location: e.location,
+    price: e.price,
+    cover_image_url: e.cover_image_url,
+  }));
+
+  return {
+    events: miniEvents,
+    totalCount: totalCount ?? 0,
+    filterUrl: buildFilterUrl(parsed),
+  };
+}
+
+/** Build a filter URL for the events page from parsed params */
+export function buildFilterUrl(parsed: ParsedSearchParams): string {
+  const parts: string[] = [];
+  if (parsed.search) parts.push(`search=${encodeURIComponent(parsed.search)}`);
+  if (parsed.type) parts.push(`type=${parsed.type}`);
+  if (parsed.dateFrom) parts.push(`from=${parsed.dateFrom}`);
+  if (parsed.dateTo) parts.push(`to=${parsed.dateTo}`);
+  if (parsed.when) parts.push(`when=${parsed.when}`);
+  if (parsed.distance) parts.push(`distance=${parsed.distance}`);
+  if (parsed.difficulty) parts.push(`difficulty=${parsed.difficulty}`);
+  return `/events${parts.length > 0 ? `?${parts.join("&")}` : ""}`;
+}

--- a/src/lib/ai/agent/index.ts
+++ b/src/lib/ai/agent/index.ts
@@ -1,0 +1,36 @@
+import { ChatAnthropic } from "@langchain/anthropic";
+import { type BaseCheckpointSaver } from "@langchain/langgraph";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+
+import { buildCocoSystemPrompt } from "./system-prompt";
+import { createAllTools } from "./tools";
+import { type AgentContext } from "./types";
+
+interface CreateCocoAgentOptions {
+  ctx: AgentContext;
+  checkpointer?: BaseCheckpointSaver;
+}
+
+/**
+ * Creates a Coco ReAct agent with tools bound to the given auth context.
+ * Agent is created per-request (tools need per-request Supabase client).
+ * Checkpointer is shared across requests for multi-turn memory.
+ */
+export function createCocoAgent({ ctx, checkpointer }: CreateCocoAgentOptions) {
+  const model = new ChatAnthropic({
+    model: "claude-haiku-4-5-20251001",
+    temperature: 0,
+    maxTokens: 1024,
+    anthropicApiKey: process.env.ANTHROPIC_CHAT_API_KEY,
+  });
+
+  const tools = createAllTools(ctx);
+  const systemPrompt = buildCocoSystemPrompt(ctx);
+
+  return createReactAgent({
+    llm: model,
+    tools,
+    prompt: systemPrompt,
+    checkpointer,
+  });
+}

--- a/src/lib/ai/agent/system-prompt.ts
+++ b/src/lib/ai/agent/system-prompt.ts
@@ -1,0 +1,52 @@
+import { type AgentContext } from "./types";
+
+export function buildCocoSystemPrompt(ctx: AgentContext): string {
+  const now = new Date();
+  const today = now.toISOString().split("T")[0];
+  const dayOfWeek = now.toLocaleDateString("en-US", { weekday: "long" });
+  const currentMonth = now.toLocaleDateString("en-US", { month: "long" });
+  const currentYear = now.getFullYear();
+
+  const authSection = ctx.userId
+    ? `The user is logged in${ctx.userName ? ` as "${ctx.userName}"` : ""}. You can look up their bookings, badges, and clubs.`
+    : "The user is NOT logged in. If they ask about personal data (bookings, badges, clubs), tell them to log in first.";
+
+  const locationSection = ctx.userLocation
+    ? `The user's current location is: lat ${ctx.userLocation.lat.toFixed(4)}, lng ${ctx.userLocation.lng.toFixed(4)}.`
+    : "";
+
+  return `You are Coco, EventTara's friendly AI assistant for Philippine outdoor adventure events (hiking, MTB, road biking, running, trail running).
+
+Today is ${dayOfWeek}, ${today}. Current month: ${currentMonth} ${currentYear}.
+
+${authSection}
+${locationSection}
+
+## Your Personality
+- Warm, enthusiastic about outdoor adventures in the Philippines
+- Concise: 2-3 sentences unless the user asks for more detail
+- Use the user's name when known
+- Never invent data — only report what your tools return
+- If a tool returns no results, say so honestly and suggest alternatives
+
+## Tool Usage
+- Use searchEvents to find events by type, date, location, difficulty, distance
+- Use getEventDetails for full info about a specific event
+- Use getEventRoute for trail/route information
+- Use getClubInfo for club details and upcoming events
+- Use getUserBookings, getUserBadges, getUserClubs for personal data (requires login)
+- Use getLeaderboard for rankings
+
+## Response Format
+- When showing events, provide markdown links: [Event Name](/events/{id})
+- Autocorrect Philippine mountain name typos (e.g., "pulog" → "Pulag", "npaulak" → "Napulak")
+- For pricing questions, show the price from the data — don't redirect to event pages
+- Format dates naturally (e.g., "Saturday, March 15" not "2026-03-15")
+- Use ₱ for prices (e.g., ₱1,500)
+
+## Important Rules
+- NEVER make up events, prices, dates, or any data
+- If you don't have the information, say so
+- Don't answer questions unrelated to EventTara, outdoor adventures, or the user's account
+- Keep responses focused and helpful`;
+}

--- a/src/lib/ai/agent/tools/get-club-info.ts
+++ b/src/lib/ai/agent/tools/get-club-info.ts
@@ -1,0 +1,81 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { type AgentContext } from "../types";
+
+export function createGetClubInfoTool(ctx: AgentContext) {
+  return tool(
+    async (input) => {
+      try {
+        // Try by slug first, then by name search
+        let club: {
+          id: string;
+          name: string;
+          slug: string;
+          description: string | null;
+          logo_url: string | null;
+          location: string | null;
+        } | null = null;
+
+        const { data: bySlug } = await ctx.supabase
+          .from("clubs")
+          .select("id, name, slug, description, logo_url, location")
+          .eq("slug", input.clubIdentifier)
+          .single();
+
+        if (bySlug) {
+          club = bySlug;
+        } else {
+          const { data: byName } = await ctx.supabase
+            .from("clubs")
+            .select("id, name, slug, description, logo_url, location")
+            .ilike("name", `%${input.clubIdentifier}%`)
+            .limit(1)
+            .single();
+          club = byName;
+        }
+
+        if (!club) {
+          return `No club found matching "${input.clubIdentifier}".`;
+        }
+
+        // Get member count
+        const { count: memberCount } = await ctx.supabase
+          .from("club_members")
+          .select("id", { count: "exact", head: true })
+          .eq("club_id", club.id);
+
+        // Get upcoming events
+        const today = new Date().toISOString().split("T")[0];
+        const { data: upcomingEvents } = await ctx.supabase
+          .from("events")
+          .select("id, title, type, date, location, price")
+          .eq("club_id", club.id)
+          .eq("status", "published")
+          .gte("date", today)
+          .order("date", { ascending: true })
+          .limit(5);
+
+        return JSON.stringify({
+          name: club.name,
+          slug: club.slug,
+          description: club.description,
+          location: club.location,
+          memberCount: memberCount ?? 0,
+          upcomingEvents: upcomingEvents ?? [],
+          clubUrl: `/clubs/${club.slug}`,
+        });
+      } catch (error) {
+        return `Error fetching club info: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "getClubInfo",
+      description:
+        "Get details about a club including description, member count, location, and upcoming events.",
+      schema: z.object({
+        clubIdentifier: z.string().describe("Club slug or name to search for"),
+      }),
+    },
+  );
+}

--- a/src/lib/ai/agent/tools/get-event-details.ts
+++ b/src/lib/ai/agent/tools/get-event-details.ts
@@ -1,0 +1,88 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { type AgentContext } from "../types";
+
+export function createGetEventDetailsTool(ctx: AgentContext) {
+  return tool(
+    async (input) => {
+      try {
+        const { data: event, error } = await ctx.supabase
+          .from("events")
+          .select(
+            "id, title, description, type, date, end_date, location, price, max_participants, difficulty_level, cover_image_url, status, club_id",
+          )
+          .eq("id", input.eventId)
+          .single();
+
+        if (error || !event) {
+          return "Event not found.";
+        }
+
+        // Get club name
+        const { data: club } = await ctx.supabase
+          .from("clubs")
+          .select("name, slug")
+          .eq("id", event.club_id)
+          .single();
+
+        // Get distances
+        const { data: distances } = await ctx.supabase
+          .from("event_distances")
+          .select("distance_km, label")
+          .eq("event_id", input.eventId);
+
+        // Get mountains
+        const { data: eventMountains } = await ctx.supabase
+          .from("event_mountains")
+          .select("mountain_id")
+          .eq("event_id", input.eventId);
+
+        let mountains: { name: string; elevation_masl: number | null }[] = [];
+        if (eventMountains && eventMountains.length > 0) {
+          const mountainIds = eventMountains.map((em) => em.mountain_id);
+          const { data: mountainData } = await ctx.supabase
+            .from("mountains")
+            .select("name, elevation_masl")
+            .in("id", mountainIds);
+          mountains = mountainData ?? [];
+        }
+
+        // Get current booking count
+        const { count: bookingCount } = await ctx.supabase
+          .from("bookings")
+          .select("id", { count: "exact", head: true })
+          .eq("event_id", input.eventId)
+          .in("status", ["pending", "confirmed"]);
+
+        return JSON.stringify({
+          id: event.id,
+          title: event.title,
+          description: event.description,
+          type: event.type,
+          date: event.date,
+          endDate: event.end_date,
+          location: event.location,
+          price: event.price,
+          maxParticipants: event.max_participants,
+          currentBookings: bookingCount ?? 0,
+          difficultyLevel: event.difficulty_level,
+          status: event.status,
+          club: club ? { name: club.name, slug: club.slug } : null,
+          distances: distances ?? [],
+          mountains,
+        });
+      } catch (error) {
+        return `Error fetching event details: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "getEventDetails",
+      description:
+        "Get full details about a specific event including description, price, difficulty, distances, mountains, and booking availability.",
+      schema: z.object({
+        eventId: z.string().describe("The event ID to look up"),
+      }),
+    },
+  );
+}

--- a/src/lib/ai/agent/tools/get-event-route.ts
+++ b/src/lib/ai/agent/tools/get-event-route.ts
@@ -1,0 +1,46 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { type AgentContext } from "../types";
+
+export function createGetEventRouteTool(ctx: AgentContext) {
+  return tool(
+    async (input) => {
+      try {
+        const { data: routes, error } = await ctx.supabase
+          .from("event_routes")
+          .select("id, name, distance, elevation_gain, source, gpx_url, strava_route_id")
+          .eq("event_id", input.eventId);
+
+        if (error) {
+          return `Error fetching routes: ${error.message}`;
+        }
+
+        if (!routes || routes.length === 0) {
+          return "No route information available for this event.";
+        }
+
+        return JSON.stringify(
+          routes.map((r) => ({
+            name: r.name,
+            distanceKm: r.distance,
+            elevationGainM: r.elevation_gain,
+            source: r.source,
+            hasGpx: !!r.gpx_url,
+            hasStravaRoute: !!r.strava_route_id,
+          })),
+        );
+      } catch (error) {
+        return `Error fetching route info: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "getEventRoute",
+      description:
+        "Get trail/route information for an event, including distance, elevation gain, and route type.",
+      schema: z.object({
+        eventId: z.string().describe("The event ID to look up routes for"),
+      }),
+    },
+  );
+}

--- a/src/lib/ai/agent/tools/get-leaderboard.ts
+++ b/src/lib/ai/agent/tools/get-leaderboard.ts
@@ -1,0 +1,101 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { type AgentContext } from "../types";
+
+export function createGetLeaderboardTool(ctx: AgentContext) {
+  return tool(
+    async (input) => {
+      try {
+        const metric = input.metric ?? "badges";
+        const limit = 10;
+
+        if (metric === "badges") {
+          // Top users by badge count
+          const { data, error } = await ctx.supabase.from("user_badges").select("user_id");
+
+          if (error) return `Error fetching leaderboard: ${error.message}`;
+          if (!data || data.length === 0) return "No leaderboard data available.";
+
+          // Count badges per user
+          const counts = new Map<string, number>();
+          for (const row of data) {
+            counts.set(row.user_id, (counts.get(row.user_id) ?? 0) + 1);
+          }
+
+          const sorted = [...counts.entries()].sort(([, a], [, b]) => b - a).slice(0, limit);
+
+          const userIds = sorted.map(([id]) => id);
+          const { data: users } = await ctx.supabase
+            .from("users")
+            .select("id, full_name, username, avatar_url")
+            .in("id", userIds);
+
+          const userMap = new Map((users ?? []).map((u) => [u.id, u]));
+
+          const leaderboard = sorted.map(([userId, count], i) => {
+            const user = userMap.get(userId);
+            return {
+              rank: i + 1,
+              name: user?.full_name ?? "Unknown",
+              username: user?.username,
+              badgeCount: count,
+            };
+          });
+
+          return JSON.stringify({ metric: "badges", leaderboard });
+        }
+
+        if (metric === "events") {
+          // Top users by event check-in count
+          const { data, error } = await ctx.supabase.from("event_checkins").select("user_id");
+
+          if (error) return `Error fetching leaderboard: ${error.message}`;
+          if (!data || data.length === 0) return "No leaderboard data available.";
+
+          const counts = new Map<string, number>();
+          for (const row of data) {
+            counts.set(row.user_id, (counts.get(row.user_id) ?? 0) + 1);
+          }
+
+          const sorted = [...counts.entries()].sort(([, a], [, b]) => b - a).slice(0, limit);
+
+          const userIds = sorted.map(([id]) => id);
+          const { data: users } = await ctx.supabase
+            .from("users")
+            .select("id, full_name, username, avatar_url")
+            .in("id", userIds);
+
+          const userMap = new Map((users ?? []).map((u) => [u.id, u]));
+
+          const leaderboard = sorted.map(([userId, count], i) => {
+            const user = userMap.get(userId);
+            return {
+              rank: i + 1,
+              name: user?.full_name ?? "Unknown",
+              username: user?.username,
+              eventCount: count,
+            };
+          });
+
+          return JSON.stringify({ metric: "events", leaderboard });
+        }
+
+        return "Invalid metric. Use 'badges' or 'events'.";
+      } catch (error) {
+        return `Error fetching leaderboard: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "getLeaderboard",
+      description:
+        "Get leaderboard rankings. Available metrics: 'badges' (most badges earned), 'events' (most events attended).",
+      schema: z.object({
+        metric: z
+          .enum(["badges", "events"])
+          .optional()
+          .describe("Ranking metric (default: badges)"),
+      }),
+    },
+  );
+}

--- a/src/lib/ai/agent/tools/get-user-badges.ts
+++ b/src/lib/ai/agent/tools/get-user-badges.ts
@@ -1,0 +1,75 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { type AgentContext } from "../types";
+
+export function createGetUserBadgesTool(ctx: AgentContext) {
+  return tool(
+    async (input) => {
+      try {
+        if (input.mode === "available") {
+          // List all available badges
+          const { data: badges, error } = await ctx.supabase
+            .from("badges")
+            .select("id, title, description, category, rarity, type")
+            .order("rarity", { ascending: true })
+            .limit(20);
+
+          if (error) return `Error fetching badges: ${error.message}`;
+          if (!badges || badges.length === 0) return "No badges available.";
+
+          return JSON.stringify(badges);
+        }
+
+        // Default: user's earned badges
+        if (!ctx.userId) {
+          return "User is not logged in. Please ask them to log in to view their badges.";
+        }
+
+        const { data: userBadges, error } = await ctx.supabase
+          .from("user_badges")
+          .select("badge_id, awarded_at")
+          .eq("user_id", ctx.userId)
+          .order("awarded_at", { ascending: false });
+
+        if (error) return `Error fetching user badges: ${error.message}`;
+        if (!userBadges || userBadges.length === 0) return "User has no badges yet.";
+
+        // Get badge details
+        const badgeIds = userBadges.map((ub) => ub.badge_id);
+        const { data: badges } = await ctx.supabase
+          .from("badges")
+          .select("id, title, description, category, rarity")
+          .in("id", badgeIds);
+
+        const badgeMap = new Map((badges ?? []).map((b) => [b.id, b]));
+
+        const result = userBadges.map((ub) => {
+          const badge = badgeMap.get(ub.badge_id);
+          return {
+            title: badge?.title,
+            description: badge?.description,
+            category: badge?.category,
+            rarity: badge?.rarity,
+            awardedAt: ub.awarded_at,
+          };
+        });
+
+        return JSON.stringify({ badges: result, totalCount: result.length });
+      } catch (error) {
+        return `Error fetching badges: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "getUserBadges",
+      description:
+        "Get the user's earned badges or list all available badges. Requires authentication for user badges.",
+      schema: z.object({
+        mode: z
+          .enum(["earned", "available"])
+          .optional()
+          .describe("'earned' for user's badges (default), 'available' for all badges"),
+      }),
+    },
+  );
+}

--- a/src/lib/ai/agent/tools/get-user-bookings.ts
+++ b/src/lib/ai/agent/tools/get-user-bookings.ts
@@ -1,0 +1,81 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { type AgentContext } from "../types";
+
+export function createGetUserBookingsTool(ctx: AgentContext) {
+  return tool(
+    async (input) => {
+      if (!ctx.userId) {
+        return "User is not logged in. Please ask them to log in to view their bookings.";
+      }
+
+      try {
+        let query = ctx.supabase
+          .from("bookings")
+          .select("id, event_id, status, payment_status, booked_at")
+          .eq("user_id", ctx.userId);
+
+        if (input.status) {
+          query = query.eq("status", input.status);
+        }
+
+        query = query.order("booked_at", { ascending: false }).limit(10);
+
+        const { data: bookings, error } = await query;
+
+        if (error) {
+          return `Error fetching bookings: ${error.message}`;
+        }
+
+        if (!bookings || bookings.length === 0) {
+          return "No bookings found.";
+        }
+
+        // Fetch event details for each booking
+        const eventIds = [...new Set(bookings.map((b) => b.event_id))];
+        const { data: events } = await ctx.supabase
+          .from("events")
+          .select("id, title, type, date, location, price")
+          .in("id", eventIds);
+
+        const eventMap = new Map((events ?? []).map((e) => [e.id, e]));
+
+        const result = bookings.map((b) => {
+          const event = eventMap.get(b.event_id);
+          return {
+            bookingId: b.id,
+            status: b.status,
+            paymentStatus: b.payment_status,
+            bookedAt: b.booked_at,
+            event: event
+              ? {
+                  id: event.id,
+                  title: event.title,
+                  type: event.type,
+                  date: event.date,
+                  location: event.location,
+                  price: event.price,
+                }
+              : null,
+          };
+        });
+
+        return JSON.stringify(result);
+      } catch (error) {
+        return `Error fetching bookings: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "getUserBookings",
+      description:
+        "Get the logged-in user's event bookings with status and event info. Requires authentication.",
+      schema: z.object({
+        status: z
+          .enum(["pending", "confirmed", "cancelled"])
+          .optional()
+          .describe("Filter by booking status"),
+      }),
+    },
+  );
+}

--- a/src/lib/ai/agent/tools/get-user-clubs.ts
+++ b/src/lib/ai/agent/tools/get-user-clubs.ts
@@ -1,0 +1,55 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { type AgentContext } from "../types";
+
+export function createGetUserClubsTool(ctx: AgentContext) {
+  return tool(
+    async () => {
+      if (!ctx.userId) {
+        return "User is not logged in. Please ask them to log in to view their clubs.";
+      }
+
+      try {
+        const { data: memberships, error } = await ctx.supabase
+          .from("club_members")
+          .select("club_id, role, joined_at")
+          .eq("user_id", ctx.userId);
+
+        if (error) return `Error fetching clubs: ${error.message}`;
+        if (!memberships || memberships.length === 0) return "User is not a member of any clubs.";
+
+        const clubIds = memberships.map((m) => m.club_id);
+        const { data: clubs } = await ctx.supabase
+          .from("clubs")
+          .select("id, name, slug, description, location")
+          .in("id", clubIds);
+
+        const clubMap = new Map((clubs ?? []).map((c) => [c.id, c]));
+
+        const result = memberships.map((m) => {
+          const club = clubMap.get(m.club_id);
+          return {
+            name: club?.name,
+            slug: club?.slug,
+            description: club?.description,
+            location: club?.location,
+            role: m.role,
+            joinedAt: m.joined_at,
+            clubUrl: club ? `/clubs/${club.slug}` : null,
+          };
+        });
+
+        return JSON.stringify(result);
+      } catch (error) {
+        return `Error fetching clubs: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "getUserClubs",
+      description:
+        "Get the clubs that the logged-in user is a member of, including their role in each club. Requires authentication.",
+      schema: z.object({}),
+    },
+  );
+}

--- a/src/lib/ai/agent/tools/index.ts
+++ b/src/lib/ai/agent/tools/index.ts
@@ -1,0 +1,28 @@
+import { type StructuredToolInterface } from "@langchain/core/tools";
+
+import { type AgentContext } from "../types";
+
+import { createGetClubInfoTool } from "./get-club-info";
+import { createGetEventDetailsTool } from "./get-event-details";
+import { createGetEventRouteTool } from "./get-event-route";
+import { createGetLeaderboardTool } from "./get-leaderboard";
+import { createGetUserBadgesTool } from "./get-user-badges";
+import { createGetUserBookingsTool } from "./get-user-bookings";
+import { createGetUserClubsTool } from "./get-user-clubs";
+import { createSearchEventsTool } from "./search-events";
+
+/**
+ * Creates all Coco agent tools bound to the given auth context.
+ */
+export function createAllTools(ctx: AgentContext): StructuredToolInterface[] {
+  return [
+    createSearchEventsTool(ctx),
+    createGetEventDetailsTool(ctx),
+    createGetEventRouteTool(ctx),
+    createGetClubInfoTool(ctx),
+    createGetUserBookingsTool(ctx),
+    createGetUserBadgesTool(ctx),
+    createGetUserClubsTool(ctx),
+    createGetLeaderboardTool(ctx),
+  ];
+}

--- a/src/lib/ai/agent/tools/search-events.ts
+++ b/src/lib/ai/agent/tools/search-events.ts
@@ -1,0 +1,76 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import { executeEventSearch } from "../event-query-builder";
+import { type AgentContext } from "../types";
+
+export function createSearchEventsTool(ctx: AgentContext) {
+  return tool(
+    async (input) => {
+      try {
+        const parsed = {
+          search: input.search,
+          type: input.type,
+          dateFrom: input.dateFrom,
+          dateTo: input.dateTo,
+          when: input.when,
+          duration: input.duration,
+          distance: input.distance,
+          difficulty: input.difficulty,
+          nearMe: input.nearMe,
+          reply: "",
+        };
+
+        const result = await executeEventSearch({
+          supabase: ctx.supabase,
+          parsed,
+          userLocation: ctx.userLocation,
+        });
+
+        if (result.events.length === 0) {
+          return JSON.stringify({
+            message: "No events found matching the criteria.",
+            totalCount: 0,
+            filterUrl: result.filterUrl,
+          });
+        }
+
+        return JSON.stringify({
+          events: result.events,
+          totalCount: result.totalCount,
+          filterUrl: result.filterUrl,
+        });
+      } catch (error) {
+        return `Error searching events: ${error instanceof Error ? error.message : "Unknown error"}`;
+      }
+    },
+    {
+      name: "searchEvents",
+      description:
+        "Search for outdoor adventure events by type, date, location, difficulty, and distance. Returns up to 3 matching events with a total count.",
+      schema: z.object({
+        search: z
+          .string()
+          .optional()
+          .describe("Search text for event title, location, or club/guide name"),
+        type: z
+          .enum(["hiking", "mtb", "road_bike", "running", "trail_run"])
+          .optional()
+          .describe("Activity type filter"),
+        dateFrom: z.string().optional().describe("Start date filter (YYYY-MM-DD)"),
+        dateTo: z.string().optional().describe("End date filter (YYYY-MM-DD)"),
+        when: z.enum(["upcoming", "now", "past"]).optional().describe("Relative time filter"),
+        duration: z
+          .enum(["single", "multi"])
+          .optional()
+          .describe("single = dayhike, multi = overnight/multi-day"),
+        distance: z.number().optional().describe("Distance in km (e.g., 42 for marathon)"),
+        difficulty: z
+          .string()
+          .optional()
+          .describe('Difficulty range "min-max" on 1-9 scale (e.g., "1-4" for easy)'),
+        nearMe: z.boolean().optional().describe("Sort by distance from user location"),
+      }),
+    },
+  );
+}

--- a/src/lib/ai/agent/types.ts
+++ b/src/lib/ai/agent/types.ts
@@ -1,0 +1,33 @@
+import { type SupabaseClient } from "@supabase/supabase-js";
+
+import { type Database } from "@/lib/supabase/types";
+
+/** Authenticated Supabase client passed to tools via closure */
+export type AgentSupabaseClient = SupabaseClient<Database>;
+
+/** Context passed to the agent factory — includes auth state and optional location */
+export interface AgentContext {
+  supabase: AgentSupabaseClient;
+  userId: string | null;
+  userName: string | null;
+  userLocation: { lat: number; lng: number } | null;
+}
+
+/** SSE event types sent to the client */
+export type SSEEvent =
+  | { type: "token"; content: string }
+  | { type: "tool_start"; name: string }
+  | { type: "tool_result"; name: string; data: unknown }
+  | { type: "done" }
+  | { type: "error"; message: string };
+
+/** Mini event for tool results (same shape as existing ChatEventCard) */
+export interface MiniEventResult {
+  id: string;
+  title: string;
+  type: string;
+  date: string;
+  location: string;
+  price: number;
+  cover_image_url: string | null;
+}

--- a/src/lib/cms/cached.ts
+++ b/src/lib/cms/cached.ts
@@ -292,6 +292,18 @@ export async function isEwalletPaymentsEnabled(): Promise<boolean> {
 }
 
 /**
+ * Returns whether the LangGraph chat agent v2 is enabled.
+ */
+export async function isChatAgentV2Enabled(): Promise<boolean> {
+  try {
+    const flags = await getCachedFeatureFlags();
+    return flags?.chat_agent_v2 === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Returns whether the club reviews feature flag is enabled.
  */
 export async function isClubReviewsEnabled(): Promise<boolean> {

--- a/src/lib/cms/types.ts
+++ b/src/lib/cms/types.ts
@@ -75,6 +75,7 @@ export interface CmsFeatureFlags {
   oauth_strava: boolean;
   oauth_facebook: boolean;
   onboarding_quiz: boolean;
+  chat_agent_v2: boolean;
 }
 
 /** A single homepage section entry inside cms_homepage_sections.sections JSONB */


### PR DESCRIPTION
## Summary

- Upgrade Coco from a simple search-to-JSON pipeline to a full **ReAct agent** (LangGraph.js) with multi-turn conversations, personalized answers, and SSE streaming responses
- Add **8 Supabase tools**: `searchEvents`, `getEventDetails`, `getEventRoute`, `getClubInfo`, `getUserBookings`, `getUserBadges`, `getUserClubs`, `getLeaderboard`
- Feature-flagged behind `chat_agent_v2` — no user impact until enabled in Supabase

### Key changes

- **Agent core** (`src/lib/ai/agent/`): `createCocoAgent()` factory with Claude Haiku 4.5, `MemorySaver` checkpointer for multi-turn memory, conversational system prompt
- **Extracted query builder**: Event search logic extracted from route.ts into `event-query-builder.ts`, shared by both legacy and agent paths
- **API route** (`route.ts`): Feature-flagged dual path — SSE streaming when `chat_agent_v2` enabled + `threadId` present, otherwise unchanged legacy JSON path
- **Frontend** (`ChatPanel.tsx`, `ChatMessage.tsx`): `threadId` generation, SSE stream consumption with content-type detection, streaming cursor, tool activity indicators ("Searching events...", "Checking your bookings...")
- **Feature flag**: Added `chat_agent_v2` to `CmsFeatureFlags` type, `isChatAgentV2Enabled()` helper, DebugToolPanel entry

### New dependencies

- `@langchain/langgraph` ^1.2.x — ReAct agent, MemorySaver checkpointer
- `@langchain/anthropic` ^1.3.x — ChatAnthropic model binding
- `@langchain/core` ^1.1.x — Base types (messages, tools, runnables)
- `zod` ^4.3.x — Tool schema validation

## Test plan

- [x] `pnpm typecheck` — passes (0 errors)
- [x] `pnpm lint` — passes (0 errors, warnings are pre-existing)
- [x] `pnpm test` — 119/119 tests pass
- [ ] Enable `chat_agent_v2` flag in Supabase, test in dev:
  - "What hiking events are coming up?" → should call searchEvents
  - "Tell me about my bookings" → should call getUserBookings (authenticated)
  - "Tell me about my bookings" (unauthenticated) → should say "please log in"
  - Multi-turn: "Show me hiking events" → "What about near Manila?" → should maintain context
- [ ] Verify streaming: tokens appear incrementally in chat UI
- [ ] Verify legacy path still works when flag is off
- [ ] Rate limiting: 30/day cap still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)