### PR TITLE
feat: hide demo banners in production

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -318,7 +318,7 @@ export default async function Home() {
 
   return (
     <main>
-      <EntryBanner />
+      {process.env.NEXT_PUBLIC_DEMO_MODE === "true" && <EntryBanner />}
 
       {enabledSections.map((section) => (
         <div key={section.key}>

--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -258,7 +258,9 @@ export default function ClientShell({
               : ""
           }`}
         >
-          {!isLighthouse && <DemoBanner isLoggedIn={!loading && !!user && !user.is_anonymous} />}
+          {!isLighthouse && process.env.NEXT_PUBLIC_DEMO_MODE === "true" && (
+            <DemoBanner isLoggedIn={!loading && !!user && !user.is_anonymous} />
+          )}
           <Navbar
             user={user}
             canManage={canManage}


### PR DESCRIPTION
## Summary
- Gate DemoBanner ("This is a demo | Try as Organizer/Participant") behind `NEXT_PUBLIC_DEMO_MODE` env var
- Gate EntryBanner ("Welcome to EventTara Beta!") behind the same env var
- Set `NEXT_PUBLIC_DEMO_MODE=true` on staging Vercel; leave unset for production

## Test plan
- [x] Demo banners visible on staging with `NEXT_PUBLIC_DEMO_MODE=true`
- [x] Demo banners hidden in production without the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)