### PR TITLE
feat: add scroll reveal animations to landing page

### DIFF
--- a/src/components/landing/NewLandingPage.tsx
+++ b/src/components/landing/NewLandingPage.tsx
@@ -10,6 +10,7 @@ import FeaturesSection from "@/components/landing/FeaturesSection";
 import FullBleedCTASection from "@/components/landing/FullBleedCTASection";
 import HeroSection from "@/components/landing/HeroSection";
 import PioneerCounterSection from "@/components/landing/PioneerCounterSection";
+import ScrollReveal from "@/components/landing/ScrollReveal";
 import TestimonialsSection from "@/components/landing/TestimonialsSection";
 import WaitlistSection from "@/components/landing/WaitlistSection";
 
@@ -25,23 +26,45 @@ export default function NewLandingPage({ heroData }: NewLandingPageProps) {
   return (
     <>
       <HeroSection heroData={heroData} />
-      <AppPreviewSection />
-      <CocoDemoSection />
-      <FullBleedCTASection />
-      <Suspense>
-        <ClubsSection />
-      </Suspense>
-      <Suspense>
-        <BentoEventsSection />
-      </Suspense>
-      <FeaturesSection />
-      <Suspense>
-        <TestimonialsSection />
-      </Suspense>
-      <PioneerCounterSection />
-      <FAQSection />
-      <WaitlistSection />
-      <ContactCTASection />
+      <ScrollReveal>
+        <AppPreviewSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <CocoDemoSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <FullBleedCTASection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <Suspense>
+          <ClubsSection />
+        </Suspense>
+      </ScrollReveal>
+      <ScrollReveal>
+        <Suspense>
+          <BentoEventsSection />
+        </Suspense>
+      </ScrollReveal>
+      <ScrollReveal>
+        <FeaturesSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <Suspense>
+          <TestimonialsSection />
+        </Suspense>
+      </ScrollReveal>
+      <ScrollReveal>
+        <PioneerCounterSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <FAQSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <WaitlistSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <ContactCTASection />
+      </ScrollReveal>
     </>
   );
 }

--- a/src/components/landing/ScrollReveal.tsx
+++ b/src/components/landing/ScrollReveal.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ScrollRevealProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function ScrollReveal({ children, className }: ScrollRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className={cn(isVisible ? "animate-fade-up" : "opacity-0", className)}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created `ScrollReveal` client component using `IntersectionObserver` (threshold 0.1, triggers once, auto-disconnects)
- Wrapped all 11 landing page sections below the hero with `<ScrollReveal>` for fade-up entrance animations
- Reuses existing `animate-fade-up` Tailwind keyframe (0.4s ease-out, 10px translateY)

## Test plan
- [ ] Visit the landing page and scroll down — each section should fade up as it enters the viewport
- [ ] Scroll back up — sections should remain visible (trigger-once behavior)
- [ ] Verify hero section renders immediately without animation delay
- [ ] Test on mobile viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)