### PR TITLE
fix: downgrade pioneer badges to epic rarity

### DIFF
--- a/src/lib/constants/system-badges.ts
+++ b/src/lib/constants/system-badges.ts
@@ -154,7 +154,7 @@ export const SYSTEM_BADGES: SystemBadge[] = [
     title: "Check-in Pioneer",
     description: "Among the first 100 users to check in on EventTara",
     category: "special",
-    rarity: "legendary",
+    rarity: "epic",
     imageUrl: "🚀",
   },
   // Pioneer (signup)
@@ -163,8 +163,8 @@ export const SYSTEM_BADGES: SystemBadge[] = [
     title: "Pioneer Participant",
     description: "Among the first 250 users to join EventTara",
     category: "special",
-    rarity: "legendary",
-    imageUrl: "🌟",
+    rarity: "epic",
+    imageUrl: "⭐",
   },
   // Pioneer (club creator)
   {
@@ -172,8 +172,8 @@ export const SYSTEM_BADGES: SystemBadge[] = [
     title: "Pioneer Club Creator",
     description: "Among the first 50 clubs created on EventTara",
     category: "special",
-    rarity: "legendary",
-    imageUrl: "🏔️",
+    rarity: "epic",
+    imageUrl: "🏕️",
   },
   // First review
   {

--- a/supabase/migrations/20260313_pioneer_badges_epic.sql
+++ b/supabase/migrations/20260313_pioneer_badges_epic.sql
@@ -1,0 +1,9 @@
+-- Downgrade pioneer badges from legendary to epic rarity
+UPDATE badges SET rarity = 'epic', image_url = '🚀'
+WHERE criteria_key = 'pioneer' AND type = 'system';
+
+UPDATE badges SET rarity = 'epic', image_url = '⭐'
+WHERE criteria_key = 'pioneer_participant' AND type = 'system';
+
+UPDATE badges SET rarity = 'epic', image_url = '🏕️'
+WHERE criteria_key = 'pioneer_organizer' AND type = 'system';


### PR DESCRIPTION
## Summary
- Change all 3 pioneer badges (check-in, participant, club creator) from `legendary` to `epic` rarity
- Update emojis: pioneer_participant `🌟` → `⭐`, pioneer_organizer `🏔️` → `🏕️`
- Legendary is now reserved for truly difficult achievements (Everest, 50 Events, Panay Mountaineer, etc.)

## Test plan
- [x] Run SQL migration on Supabase
- [ ] `/achievements` page shows pioneer badges with purple (epic) border instead of golden (legendary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)