### PR TITLE
refactor: bulk upsert itinerary entries in a single request

### DIFF
--- a/src/app/(frontend)/api/events/[id]/itinerary/route.ts
+++ b/src/app/(frontend)/api/events/[id]/itinerary/route.ts
@@ -4,6 +4,8 @@ import { checkClubPermissionServer, CLUB_PERMISSIONS } from "@/lib/clubs/permiss
 import { nextSortOrder } from "@/lib/itinerary/sort";
 import { createClient } from "@/lib/supabase/server";
 
+const asString = (v: unknown): string => (typeof v === "string" ? v : "");
+
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id: eventId } = await params;
   const supabase = await createClient();
@@ -49,15 +51,83 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  let time: string;
-  let title: string;
+  let body: { time?: unknown; title?: unknown; entries?: unknown };
   try {
-    const body = await request.json();
-    time = String(body.time ?? "").trim();
-    title = String(body.title ?? "").trim();
+    body = (await request.json()) as { time?: unknown; title?: unknown; entries?: unknown };
   } catch {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
+
+  // Bulk path: { entries: [{ time, title }] } — upsert by (event_id, time)
+  if (Array.isArray(body.entries)) {
+    const incoming = body.entries
+      .map((e) => {
+        const obj = (e ?? {}) as { time?: unknown; title?: unknown };
+        return { time: asString(obj.time).trim(), title: asString(obj.title).trim() };
+      })
+      .filter((e) => e.time && e.title);
+
+    if (incoming.length === 0) {
+      return NextResponse.json({ entries: [] }, { status: 200 });
+    }
+
+    const { data: existing } = await supabase
+      .from("event_itinerary")
+      .select("id, time, sort_order")
+      .eq("event_id", eventId);
+
+    const existingByTime = new Map((existing ?? []).map((e) => [e.time, e]));
+
+    const toUpdate: { id: string; title: string }[] = [];
+    const toInsert: { event_id: string; time: string; title: string; sort_order: number }[] = [];
+
+    let nextOrder = nextSortOrder(existing ?? []);
+    const seenInsertTimes = new Set<string>();
+
+    for (const e of incoming) {
+      const match = existingByTime.get(e.time);
+      if (match) {
+        toUpdate.push({ id: match.id, title: e.title });
+      } else if (!seenInsertTimes.has(e.time)) {
+        seenInsertTimes.add(e.time);
+        toInsert.push({ event_id: eventId, time: e.time, title: e.title, sort_order: nextOrder++ });
+      }
+    }
+
+    const [insertResult, ...updateResults] = await Promise.all([
+      toInsert.length > 0
+        ? supabase.from("event_itinerary").insert(toInsert).select("id, time, title, sort_order")
+        : Promise.resolve({ data: [], error: null } as const),
+      ...toUpdate.map((u) =>
+        supabase
+          .from("event_itinerary")
+          .update({ title: u.title })
+          .eq("id", u.id)
+          .eq("event_id", eventId)
+          .select("id, time, title, sort_order")
+          .single(),
+      ),
+    ]);
+
+    if (insertResult.error) {
+      return NextResponse.json({ error: insertResult.error.message }, { status: 500 });
+    }
+    const updateError = updateResults.find((r) => r.error);
+    if (updateError?.error) {
+      return NextResponse.json({ error: updateError.error.message }, { status: 500 });
+    }
+
+    const entries = [
+      ...(insertResult.data ?? []),
+      ...updateResults.map((r) => r.data).filter(Boolean),
+    ];
+
+    return NextResponse.json({ entries }, { status: 201 });
+  }
+
+  // Single-entry path (legacy)
+  const time = asString(body.time).trim();
+  const title = asString(body.title).trim();
 
   if (!time || !title) {
     return NextResponse.json({ error: "time and title are required" }, { status: 400 });

--- a/src/components/dashboard/ItineraryManager.tsx
+++ b/src/components/dashboard/ItineraryManager.tsx
@@ -34,7 +34,6 @@ export default function ItineraryManager({ eventId, initialEntries }: ItineraryM
   const [pasteStep, setPasteStep] = useState<"paste" | "preview">("paste");
   const [parsedEntries, setParsedEntries] = useState<ParsedEntry[]>([]);
   const [pasteSaving, setPasteSaving] = useState(false);
-  const [pasteSavingIndex, setPasteSavingIndex] = useState(-1);
   const [pasteError, setPasteError] = useState("");
 
   useEffect(() => {
@@ -167,66 +166,40 @@ export default function ItineraryManager({ eventId, initialEntries }: ItineraryM
   }
 
   async function handlePasteSave() {
-    const validIndices = parsedEntries
-      .map((e, i) => (e.title.trim() ? i : -1))
-      .filter((i) => i !== -1);
-    if (validIndices.length === 0) return;
+    const valid = parsedEntries
+      .filter((e) => e.title.trim())
+      .map((e) => ({ time: e.time.trim(), title: e.title.trim() }));
+    if (valid.length === 0) return;
 
     setPasteSaving(true);
-    setPasteSavingIndex(-1);
     setPasteError("");
 
-    let failCount = 0;
-
     try {
-      for (const idx of validIndices) {
-        const parsed = parsedEntries[idx];
-        setPasteSavingIndex(idx);
-        const existingEntry = entries.find((e) => e.time === parsed.time.trim());
+      const res = await fetch(`/api/events/${eventId}/itinerary`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entries: valid }),
+      });
 
-        try {
-          if (existingEntry) {
-            const res = await fetch(`/api/events/${eventId}/itinerary/${existingEntry.id}`, {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ title: parsed.title.trim() }),
-            });
-            if (res.ok) {
-              const json: { entry: ItineraryEntry } = await res.json();
-              setEntries((prev) => prev.map((e) => (e.id === existingEntry.id ? json.entry : e)));
-            } else {
-              console.error("Failed to update itinerary entry:", await res.text());
-              failCount++;
-            }
-          } else {
-            const res = await fetch(`/api/events/${eventId}/itinerary`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ time: parsed.time.trim(), title: parsed.title.trim() }),
-            });
-            if (res.ok) {
-              const json: { entry: ItineraryEntry } = await res.json();
-              setEntries((prev) => [...prev, json.entry]);
-            } else {
-              console.error("Failed to add itinerary entry:", await res.text());
-              failCount++;
-            }
-          }
-        } catch (error_) {
-          console.error("Error saving itinerary entry:", error_);
-          failCount++;
-        }
+      if (!res.ok) {
+        const json: { error?: string } = await res.json().catch(() => ({}));
+        setPasteError(json.error ?? "Failed to save entries.");
+        return;
       }
-    } finally {
-      setPasteSaving(false);
-      setPasteSavingIndex(-1);
-    }
 
-    if (failCount > 0) {
-      setPasteError(`${failCount} ${failCount === 1 ? "entry" : "entries"} failed to save.`);
-    } else {
+      const json: { entries: ItineraryEntry[] } = await res.json();
+      setEntries((prev) => {
+        const byId = new Map(prev.map((e) => [e.id, e]));
+        for (const e of json.entries) byId.set(e.id, e);
+        return [...byId.values()].sort((a, b) => a.sort_order - b.sort_order);
+      });
       setPasteOpen(false);
       router.refresh();
+    } catch (error_) {
+      console.error("Error saving itinerary entries:", error_);
+      setPasteError("Failed to save entries.");
+    } finally {
+      setPasteSaving(false);
     }
   }
 
@@ -418,8 +391,8 @@ export default function ItineraryManager({ eventId, initialEntries }: ItineraryM
                     const isUpdate =
                       entry.time.trim() && entries.some((ex) => ex.time === entry.time.trim());
                     const isUnparsed = !entry.time;
-                    const isSaved = pasteSaving && i < pasteSavingIndex;
-                    const isSaving = pasteSaving && i === pasteSavingIndex;
+                    const isSaved = false;
+                    const isSaving = pasteSaving;
                     return (
                       <div
                         key={i}
@@ -516,7 +489,7 @@ export default function ItineraryManager({ eventId, initialEntries }: ItineraryM
                     }
                   >
                     {pasteSaving
-                      ? `Saving ${pasteSavingIndex + 1}/${parsedEntries.filter((e) => e.title.trim()).length}...`
+                      ? `Saving ${parsedEntries.filter((e) => e.title.trim()).length} entries...`
                       : "Add to Itinerary"}
                   </Button>
                 </>


### PR DESCRIPTION
## Summary
- Replaces the per-row POST loop in the paste-itinerary flow with a single bulk request — 35 entries used to mean 35 round-trips and a "Saving 25/35..." progress bar; now it's one call.
- API `POST /api/events/[id]/itinerary` now accepts `{ entries: [...] }`: bulk insert for new rows + parallel updates for existing-by-time matches, all server-side.
- Legacy single-entry POST path preserved so the manual "+ Add" form keeps working.

## Test plan
- [ ] Paste a multi-day itinerary with 20+ entries → saves in one request, modal closes, all rows present
- [ ] Paste with some times matching existing rows → existing rows get title updates, new rows inserted
- [ ] Manual "+ Add" form still adds a single entry
- [ ] Reorder still works