### PR TITLE
feat(admin): preview and edit email blast before sending

### DIFF
--- a/src/app/(admin)/admin/email-blast/page.tsx
+++ b/src/app/(admin)/admin/email-blast/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
 
@@ -11,16 +11,38 @@ interface EventOption {
   status: string;
 }
 
+interface BlastOverrides {
+  subject: string;
+  headline: string;
+  subtext: string;
+  customMessage: string;
+  eventLocation: string;
+  eventDate: string;
+}
+
+const EMPTY_OVERRIDES: BlastOverrides = {
+  subject: "",
+  headline: "",
+  subtext: "",
+  customMessage: "",
+  eventLocation: "",
+  eventDate: "",
+};
+
 export default function EmailBlastPage() {
   const [events, setEvents] = useState<EventOption[]>([]);
   const [selectedEventId, setSelectedEventId] = useState("");
   const [recipientCount, setRecipientCount] = useState<number | null>(null);
+  const [overrides, setOverrides] = useState<BlastOverrides>(EMPTY_OVERRIDES);
+  const [previewHtml, setPreviewHtml] = useState("");
+  const [previewLoading, setPreviewLoading] = useState(false);
   const [sending, setSending] = useState(false);
   const [result, setResult] = useState<{ sent: number; failed: number; total: number } | null>(
     null,
   );
   const [error, setError] = useState("");
   const [showConfirm, setShowConfirm] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     async function fetchEvents() {
@@ -35,16 +57,57 @@ export default function EmailBlastPage() {
     void fetchEvents();
   }, []);
 
+  // Load defaults + initial preview when event changes
   useEffect(() => {
-    async function fetchCount() {
-      const res = await fetch("/api/admin/email-blast");
-      if (res.ok) {
-        const data: { recipientCount: number } = await res.json();
-        setRecipientCount(data.recipientCount);
-      }
+    if (!selectedEventId) {
+      setOverrides(EMPTY_OVERRIDES);
+      setPreviewHtml("");
+      setRecipientCount(null);
+      return;
     }
-    void fetchCount();
-  }, []);
+
+    async function loadDefaults() {
+      const res = await fetch(`/api/admin/email-blast?eventId=${selectedEventId}`);
+      if (!res.ok) {
+        setError("Failed to load preview");
+        return;
+      }
+      const data: {
+        recipientCount: number;
+        defaults: BlastOverrides;
+        html: string;
+      } = await res.json();
+      setRecipientCount(data.recipientCount);
+      setOverrides(data.defaults);
+      setPreviewHtml(data.html);
+    }
+    void loadDefaults();
+  }, [selectedEventId]);
+
+  // Debounced live preview refresh on override changes
+  useEffect(() => {
+    if (!selectedEventId) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setPreviewLoading(true);
+      try {
+        const res = await fetch("/api/admin/email-blast/preview", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ eventId: selectedEventId, ...overrides }),
+        });
+        if (res.ok) {
+          const data: { html: string } = await res.json();
+          setPreviewHtml(data.html);
+        }
+      } finally {
+        setPreviewLoading(false);
+      }
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [overrides, selectedEventId]);
 
   async function handleSend() {
     if (!selectedEventId) return;
@@ -57,7 +120,7 @@ export default function EmailBlastPage() {
       const res = await fetch("/api/admin/email-blast", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ eventId: selectedEventId }),
+        body: JSON.stringify({ eventId: selectedEventId, ...overrides }),
       });
 
       if (!res.ok) {
@@ -77,13 +140,18 @@ export default function EmailBlastPage() {
 
   const selectedEvent = events.find((e) => e.id === selectedEventId);
 
+  function updateField<K extends keyof BlastOverrides>(key: K, value: BlastOverrides[K]) {
+    setOverrides((prev) => ({ ...prev, [key]: value }));
+  }
+
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-6xl">
       <h2 className="mb-2 font-heading text-2xl font-bold text-gray-900 dark:text-white">
         Email Blast
       </h2>
       <p className="mb-8 text-sm text-gray-500 dark:text-gray-400">
-        Send a marketing email about an upcoming event to all registered users.
+        Send a marketing email about an upcoming event to all registered users. Edit the fields
+        below and preview the email before sending.
       </p>
 
       <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -111,66 +179,180 @@ export default function EmailBlastPage() {
         ))}
       </select>
 
-      {recipientCount !== null && (
-        <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
-          This will be sent to{" "}
-          <span className="font-semibold text-gray-900 dark:text-white">
-            {recipientCount.toLocaleString()}
-          </span>{" "}
-          registered users.
-        </p>
-      )}
+      {selectedEventId && (
+        <div className="grid gap-6 lg:grid-cols-2">
+          {/* Edit fields */}
+          <div className="space-y-4">
+            <h3 className="font-heading text-lg font-semibold text-gray-900 dark:text-white">
+              Email Content
+            </h3>
 
-      {showConfirm ? (
-        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
-          <p className="mb-3 text-sm font-medium text-yellow-200">
-            Are you sure you want to send the blast for <strong>{selectedEvent?.title}</strong> to{" "}
-            {recipientCount?.toLocaleString()} users?
-          </p>
-          <div className="flex gap-3">
-            <button
-              onClick={handleSend}
-              disabled={sending}
-              className="rounded-lg bg-teal-600 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700 disabled:opacity-50"
+            <Field label="Subject">
+              <input
+                type="text"
+                value={overrides.subject}
+                onChange={(e) => updateField("subject", e.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+              />
+            </Field>
+
+            <Field
+              label="Headline"
+              hint="Big hero headline at the top. Leave blank to use the default for the event type."
             >
-              {sending ? "Sending..." : "Yes, Send Now"}
-            </button>
-            <button
-              onClick={() => setShowConfirm(false)}
-              disabled={sending}
-              className="rounded-lg border border-gray-600 px-5 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+              <input
+                type="text"
+                value={overrides.headline}
+                placeholder="The Mountain is Calling!"
+                onChange={(e) => updateField("headline", e.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+              />
+            </Field>
+
+            <Field label="Subtext" hint="One-liner under the headline. Leave blank for default.">
+              <input
+                type="text"
+                value={overrides.subtext}
+                placeholder="Lace up your boots — an epic climb awaits."
+                onChange={(e) => updateField("subtext", e.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+              />
+            </Field>
+
+            <Field
+              label="Custom Message"
+              hint="Free-text paragraph shown above the event details. Great for your own pitch or description."
             >
-              Cancel
-            </button>
+              <textarea
+                value={overrides.customMessage}
+                onChange={(e) => updateField("customMessage", e.target.value)}
+                rows={5}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+              />
+            </Field>
+
+            <Field label="Location">
+              <input
+                type="text"
+                value={overrides.eventLocation}
+                onChange={(e) => updateField("eventLocation", e.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+              />
+            </Field>
+
+            <Field label="Date Label">
+              <input
+                type="text"
+                value={overrides.eventDate}
+                onChange={(e) => updateField("eventDate", e.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+              />
+            </Field>
+
+            {recipientCount !== null && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                This will be sent to{" "}
+                <span className="font-semibold text-gray-900 dark:text-white">
+                  {recipientCount.toLocaleString()}
+                </span>{" "}
+                registered users.
+              </p>
+            )}
+
+            {showConfirm ? (
+              <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
+                <p className="mb-3 text-sm font-medium text-yellow-200">
+                  Are you sure you want to send the blast for{" "}
+                  <strong>{selectedEvent?.title}</strong> to {recipientCount?.toLocaleString()}{" "}
+                  users?
+                </p>
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleSend}
+                    disabled={sending}
+                    className="rounded-lg bg-teal-600 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700 disabled:opacity-50"
+                  >
+                    {sending ? "Sending..." : "Yes, Send Now"}
+                  </button>
+                  <button
+                    onClick={() => setShowConfirm(false)}
+                    disabled={sending}
+                    className="rounded-lg border border-gray-600 px-5 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowConfirm(true)}
+                disabled={!selectedEventId || sending}
+                className="rounded-lg bg-teal-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Send Email Blast
+              </button>
+            )}
+
+            {result && (
+              <div className="rounded-lg border border-teal-500/30 bg-teal-500/10 p-4">
+                <p className="text-sm text-teal-200">
+                  Blast sent! <strong>{result.sent}</strong> delivered
+                  {result.failed > 0 && (
+                    <span className="text-red-400">, {result.failed} failed</span>
+                  )}{" "}
+                  out of {result.total} total.
+                </p>
+              </div>
+            )}
+
+            {error && (
+              <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+                <p className="text-sm text-red-300">{error}</p>
+              </div>
+            )}
+          </div>
+
+          {/* Preview */}
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <h3 className="font-heading text-lg font-semibold text-gray-900 dark:text-white">
+                Preview
+              </h3>
+              {previewLoading && (
+                <span className="text-xs text-gray-500 dark:text-gray-400">Updating…</span>
+              )}
+            </div>
+            <div className="overflow-hidden rounded-lg border border-gray-300 bg-white dark:border-gray-700">
+              <iframe
+                title="Email preview"
+                srcDoc={previewHtml}
+                sandbox=""
+                className="h-[720px] w-full bg-white"
+              />
+            </div>
           </div>
         </div>
-      ) : (
-        <button
-          onClick={() => setShowConfirm(true)}
-          disabled={!selectedEventId || sending}
-          className="rounded-lg bg-teal-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Send Email Blast
-        </button>
       )}
+    </div>
+  );
+}
 
-      {result && (
-        <div className="mt-6 rounded-lg border border-teal-500/30 bg-teal-500/10 p-4">
-          <p className="text-sm text-teal-200">
-            Blast sent! <strong>{result.sent}</strong> delivered
-            {result.failed > 0 && (
-              <span className="text-red-400">, {result.failed} failed</span>
-            )}{" "}
-            out of {result.total} total.
-          </p>
-        </div>
-      )}
-
-      {error && (
-        <div className="mt-6 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
-          <p className="text-sm text-red-300">{error}</p>
-        </div>
-      )}
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+        {label}
+      </label>
+      {children}
+      {hint && <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
     </div>
   );
 }

--- a/src/app/(admin)/api/admin/email-blast/preview/route.ts
+++ b/src/app/(admin)/api/admin/email-blast/preview/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+
+import { isAdminUser } from "@/lib/admin/auth";
+import { upcomingEventBlastHtml } from "@/lib/email/templates/upcoming-event-blast";
+import { createClient } from "@/lib/supabase/server";
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user || !isAdminUser(user.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    eventId?: string;
+    subject?: string;
+    headline?: string;
+    subtext?: string;
+    customMessage?: string;
+    eventLocation?: string;
+    eventDate?: string;
+  } | null;
+
+  if (!body?.eventId) {
+    return NextResponse.json({ error: "eventId is required" }, { status: 400 });
+  }
+
+  const { data: event } = await supabase
+    .from("events")
+    .select(
+      "id, title, date, location, type, difficulty_level, price, cover_image_url, max_participants, offline_participants",
+    )
+    .eq("id", body.eventId)
+    .single();
+
+  if (!event) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const { count: bookedCount } = await supabase
+    .from("bookings")
+    .select("id", { count: "exact", head: true })
+    .eq("event_id", event.id)
+    .in("status", ["confirmed", "pending", "reserved"]);
+
+  const totalBooked = (bookedCount ?? 0) + (event.offline_participants ?? 0);
+  const spotsRemaining = Math.max(0, event.max_participants - totalBooked);
+
+  const defaultDate = new Date(event.date).toLocaleDateString("en-PH", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const html = upcomingEventBlastHtml({
+    eventTitle: event.title,
+    eventDate: body.eventDate?.trim() || defaultDate,
+    eventLocation: body.eventLocation?.trim() || event.location || "TBA",
+    eventType: event.type || "",
+    difficulty: event.difficulty_level,
+    price: event.price,
+    coverImageUrl: event.cover_image_url,
+    spotsRemaining,
+    maxParticipants: event.max_participants,
+    eventId: event.id,
+    userId: "preview",
+    headline: body.headline,
+    subtext: body.subtext,
+    customMessage: body.customMessage,
+  });
+
+  return NextResponse.json({ html });
+}

--- a/src/app/(admin)/api/admin/email-blast/route.ts
+++ b/src/app/(admin)/api/admin/email-blast/route.ts
@@ -5,7 +5,7 @@ import { sendBatchEmails } from "@/lib/email/send";
 import { upcomingEventBlastHtml } from "@/lib/email/templates/upcoming-event-blast";
 import { createClient } from "@/lib/supabase/server";
 
-export async function GET() {
+export async function GET(request: Request) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -29,7 +29,66 @@ export async function GET() {
 
   const recipientCount = (allUsers ?? []).filter((u) => !unsubIds.has(u.id)).length;
 
-  return NextResponse.json({ recipientCount });
+  // If eventId is provided, also return preview defaults + rendered HTML
+  const url = new URL(request.url);
+  const eventId = url.searchParams.get("eventId");
+
+  if (!eventId) {
+    return NextResponse.json({ recipientCount });
+  }
+
+  const { data: event } = await supabase
+    .from("events")
+    .select(
+      "id, title, date, location, type, difficulty_level, price, cover_image_url, max_participants, offline_participants, status",
+    )
+    .eq("id", eventId)
+    .single();
+
+  if (!event) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const { count: bookedCount } = await supabase
+    .from("bookings")
+    .select("id", { count: "exact", head: true })
+    .eq("event_id", event.id)
+    .in("status", ["confirmed", "pending", "reserved"]);
+
+  const totalBooked = (bookedCount ?? 0) + (event.offline_participants ?? 0);
+  const spotsRemaining = Math.max(0, event.max_participants - totalBooked);
+
+  const eventDate = new Date(event.date).toLocaleDateString("en-PH", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const defaults = {
+    subject: `New Climb Alert: ${event.title} — ${eventDate}`,
+    headline: "",
+    subtext: "",
+    customMessage: "",
+    eventLocation: event.location || "TBA",
+    eventDate,
+  };
+
+  const html = upcomingEventBlastHtml({
+    eventTitle: event.title,
+    eventDate: defaults.eventDate,
+    eventLocation: defaults.eventLocation,
+    eventType: event.type || "",
+    difficulty: event.difficulty_level,
+    price: event.price,
+    coverImageUrl: event.cover_image_url,
+    spotsRemaining,
+    maxParticipants: event.max_participants,
+    eventId: event.id,
+    userId: "preview",
+  });
+
+  return NextResponse.json({ recipientCount, defaults, html });
 }
 
 export async function POST(request: Request) {
@@ -48,7 +107,15 @@ export async function POST(request: Request) {
     }
   }
 
-  const body = await request.json().catch(() => null);
+  const body = (await request.json().catch(() => null)) as {
+    eventId?: string;
+    subject?: string;
+    headline?: string;
+    subtext?: string;
+    customMessage?: string;
+    eventLocation?: string;
+    eventDate?: string;
+  } | null;
   if (!body?.eventId) {
     return NextResponse.json({ error: "eventId is required" }, { status: 400 });
   }
@@ -81,13 +148,15 @@ export async function POST(request: Request) {
     const totalBooked = (bookedCount ?? 0) + (event.offline_participants ?? 0);
     const spotsRemaining = Math.max(0, event.max_participants - totalBooked);
 
-    // Format date
-    const eventDate = new Date(event.date).toLocaleDateString("en-PH", {
+    // Format date (allow override)
+    const defaultEventDate = new Date(event.date).toLocaleDateString("en-PH", {
       weekday: "long",
       year: "numeric",
       month: "long",
       day: "numeric",
     });
+    const eventDate = body.eventDate?.trim() || defaultEventDate;
+    const eventLocation = body.eventLocation?.trim() || event.location || "TBA";
 
     // Fetch all registered users with real emails (exclude Strava/guest accounts)
     const { data: allUsers } = await supabase
@@ -110,7 +179,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ sent: 0, failed: 0, total: 0 });
     }
 
-    const subject = `New Climb Alert: ${event.title} — ${eventDate}`;
+    const subject = body.subject?.trim() || `New Climb Alert: ${event.title} — ${eventDate}`;
 
     // Build per-user HTML (each email has a unique unsubscribe link)
     const emails = users.map((u) => ({
@@ -119,7 +188,7 @@ export async function POST(request: Request) {
       html: upcomingEventBlastHtml({
         eventTitle: event.title,
         eventDate,
-        eventLocation: event.location || "TBA",
+        eventLocation,
         eventType: event.type || "",
         difficulty: event.difficulty_level,
         price: event.price,
@@ -128,6 +197,9 @@ export async function POST(request: Request) {
         maxParticipants: event.max_participants,
         eventId: event.id,
         userId: u.id,
+        headline: body.headline,
+        subtext: body.subtext,
+        customMessage: body.customMessage,
       }),
     }));
 

--- a/src/lib/email/templates/layout.ts
+++ b/src/lib/email/templates/layout.ts
@@ -74,7 +74,7 @@ export function emailLayout({ title, content, footerText }: EmailLayoutProps): s
 
 /** Dark-themed CTA button */
 export function emailButton(text: string, href: string): string {
-  return `<table cellpadding="0" cellspacing="0"><tr>
+  return `<table cellpadding="0" cellspacing="0" align="center"><tr>
   <td style="background-color:#a3e635;border-radius:8px;">
     <a href="${href}" style="display:inline-block;padding:14px 32px;color:#0b1120;text-decoration:none;font-size:15px;font-weight:600;">
       ${text}

--- a/src/lib/email/templates/upcoming-event-blast.ts
+++ b/src/lib/email/templates/upcoming-event-blast.ts
@@ -14,6 +14,9 @@ interface UpcomingEventBlastProps {
   maxParticipants: number;
   eventId: string;
   userId: string;
+  headline?: string;
+  subtext?: string;
+  customMessage?: string;
 }
 
 const HYPE_HEADLINES: Record<string, { headline: string; subtext: string }> = {
@@ -44,10 +47,20 @@ const DEFAULT_HYPE = {
   subtext: "A new event is coming — don't miss your chance.",
 };
 
+function escapeHtml(str: string): string {
+  return str
+    .replaceAll('&', "&amp;")
+    .replaceAll('<', "&lt;")
+    .replaceAll('>', "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll('\'', "&#39;");
+}
+
 function difficultyStars(level: number | null): string {
   if (!level) return "";
-  const filled = "&#9733;".repeat(level);
-  const empty = "&#9734;".repeat(5 - level);
+  const clamped = Math.max(0, Math.min(5, level));
+  const filled = "&#9733;".repeat(clamped);
+  const empty = "&#9734;".repeat(5 - clamped);
   return `
     <p style="margin:0 0 8px;">
       <span style="color:#a3e635;font-weight:600;">Difficulty:</span>
@@ -68,9 +81,19 @@ export function upcomingEventBlastHtml({
   maxParticipants,
   eventId,
   userId,
+  headline,
+  subtext,
+  customMessage,
 }: UpcomingEventBlastProps): string {
   const typeLabel = ACTIVITY_TYPE_LABELS[eventType as ActivityType] || eventType;
-  const hype = HYPE_HEADLINES[eventType] || DEFAULT_HYPE;
+  const defaultHype = HYPE_HEADLINES[eventType] || DEFAULT_HYPE;
+  const hype = {
+    headline: headline?.trim() || defaultHype.headline,
+    subtext: subtext?.trim() || defaultHype.subtext,
+  };
+  const customMessageHtml = customMessage?.trim()
+    ? `<p style="color:#cbd5e1;font-size:15px;line-height:1.6;margin:0 0 24px;white-space:pre-wrap;">${escapeHtml(customMessage.trim())}</p>`
+    : "";
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://eventtara.com";
   const eventUrl = `${siteUrl}/events/${eventId}`;
   const unsubscribeUrl = `${siteUrl}/unsubscribe?uid=${userId}`;
@@ -98,6 +121,8 @@ export function upcomingEventBlastHtml({
       <p style="color:#94a3b8;font-size:15px;margin:0 0 24px;text-align:center;">
         ${hype.subtext}
       </p>
+
+      ${customMessageHtml}
 
       ${emailInfoCard(`
         <p style="color:#f1f5f9;font-size:20px;font-weight:700;margin:0 0 16px;">${eventTitle}</p>

--- a/src/lib/email/templates/upcoming-event-blast.ts
+++ b/src/lib/email/templates/upcoming-event-blast.ts
@@ -49,11 +49,11 @@ const DEFAULT_HYPE = {
 
 function escapeHtml(str: string): string {
   return str
-    .replaceAll('&', "&amp;")
-    .replaceAll('<', "&lt;")
-    .replaceAll('>', "&gt;")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
-    .replaceAll('\'', "&#39;");
+    .replaceAll("'", "&#39;");
 }
 
 function difficultyStars(level: number | null): string {


### PR DESCRIPTION
## Summary
- Admin email blast now has a live preview + editable fields (subject, headline, subtext, custom message, location, date label) before sending.
- New `POST /api/admin/email-blast/preview` endpoint renders the template with overrides; main `POST /api/admin/email-blast` also accepts the same overrides.
- Fixes `RangeError: Invalid count value: -3` when an event's `difficulty_level` is >5 (clamps to 0–5 in the stars renderer). This was the cause of the 500 on the Mt. Madja-as blast.

## Test plan
- [ ] Open `/admin/email-blast`, select an event → editable fields + iframe preview appear
- [ ] Edit headline / subtext / custom message → preview refreshes (debounced)
- [ ] Edit location + date label → preview reflects the overrides
- [ ] Send blast → confirm overrides are applied in the delivered email
- [ ] Select event with `difficulty_level > 5` → no 500, stars render capped at 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)