### PR TITLE
fix: prevent demo banner from overlapping navbar

### DIFF
--- a/src/components/layout/ClientShell.tsx
+++ b/src/components/layout/ClientShell.tsx
@@ -120,6 +120,7 @@ export default function ClientShell({
   const hadInitialUser = useRef(!!initialUser);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [navLayout] = useState<string>(initialNavLayout);
+  const [demoBannerHeight, setDemoBannerHeight] = useState(0);
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
 
@@ -285,6 +286,9 @@ export default function ClientShell({
     globalThis.location.href = "/";
   }, [supabase]);
 
+  const handleDemoBannerChange = useCallback((_visible: boolean, height: number) => {
+    setDemoBannerHeight(height);
+  }, []);
   const handleDrawerClose = useCallback(() => setDrawerOpen(false), []);
   const handleMenuOpen = useCallback(() => setDrawerOpen(true), []);
 
@@ -295,7 +299,10 @@ export default function ClientShell({
         <NavigationLoader />
         <div className={`min-h-dvh flex flex-col ${drawerOpen ? "pointer-events-none" : ""}`}>
           {!isLighthouse && process.env.NEXT_PUBLIC_DEMO_MODE === "true" && (
-            <DemoBanner isLoggedIn={!loading && !!user && !user.is_anonymous} />
+            <DemoBanner
+              isLoggedIn={!loading && !!user && !user.is_anonymous}
+              onVisibilityChange={handleDemoBannerChange}
+            />
           )}
           <Navbar
             user={user}
@@ -307,6 +314,7 @@ export default function ClientShell({
             activityFeedEnabled={activityFeedEnabled}
             avatarShopEnabled={featureFlags?.avatar_shop_enabled === true}
             isAdmin={isAdmin}
+            demoBannerHeight={demoBannerHeight}
             onLogout={() => void handleLogout()}
             onMenuOpen={handleMenuOpen}
             onBorderChange={(borderId, tier, color) => {
@@ -314,7 +322,12 @@ export default function ClientShell({
             }}
           />
           <BreadcrumbProvider>
-            <div className="flex-1 pt-14 md:pt-20 pb-16 md:pb-0">{children}</div>
+            <div
+              className="flex-1 pt-14 md:pt-20 pb-16 md:pb-0"
+              style={demoBannerHeight > 0 ? { marginTop: demoBannerHeight } : undefined}
+            >
+              {children}
+            </div>
           </BreadcrumbProvider>
           <MobileNav user={user} canManage={canManage} activityFeedEnabled={activityFeedEnabled} />
         </div>

--- a/src/components/layout/DemoBanner.tsx
+++ b/src/components/layout/DemoBanner.tsx
@@ -86,6 +86,7 @@ const DISMISS_KEY = "demo-banner-dismissed";
 
 interface DemoBannerProps {
   isLoggedIn: boolean;
+  onVisibilityChange?: (visible: boolean, height: number) => void;
 }
 
 function AccountDropdown({
@@ -150,16 +151,27 @@ function AccountDropdown({
   );
 }
 
-export default function DemoBanner({ isLoggedIn }: DemoBannerProps) {
+export default function DemoBanner({ isLoggedIn, onVisibilityChange }: DemoBannerProps) {
   const router = useRouter();
   const supabase = createClient();
+  const bannerRef = useRef<HTMLDivElement>(null);
   const [dismissed, setDismissed] = useState(() => {
     if (typeof globalThis === "undefined" || !globalThis.localStorage) return false;
     return globalThis.localStorage.getItem(DISMISS_KEY) === "true";
   });
   const [loading, setLoading] = useState<string | null>(null);
 
-  if (isLoggedIn || dismissed) return null;
+  const isVisible = !isLoggedIn && !dismissed;
+
+  useEffect(() => {
+    if (isVisible && bannerRef.current) {
+      onVisibilityChange?.(true, bannerRef.current.offsetHeight);
+    } else {
+      onVisibilityChange?.(false, 0);
+    }
+  }, [isVisible, onVisibilityChange]);
+
+  if (!isVisible) return null;
 
   const handleDemoLogin = async (account: DemoAccount) => {
     setLoading(account.email);
@@ -181,10 +193,14 @@ export default function DemoBanner({ isLoggedIn }: DemoBannerProps) {
   const handleDismiss = () => {
     localStorage.setItem(DISMISS_KEY, "true");
     setDismissed(true);
+    onVisibilityChange?.(false, 0);
   };
 
   return (
-    <div className="bg-gradient-to-r from-teal-600 to-forest-600 text-white">
+    <div
+      ref={bannerRef}
+      className="fixed top-0 left-0 right-0 z-[51] bg-gradient-to-r from-teal-600 to-forest-600 text-white"
+    >
       <div className="mx-auto max-w-7xl px-4 py-2.5 sm:px-6">
         <div className="flex items-center justify-between gap-3">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -41,6 +41,7 @@ interface NavbarProps {
   activityFeedEnabled?: boolean;
   avatarShopEnabled?: boolean;
   isAdmin?: boolean;
+  demoBannerHeight?: number;
   onLogout: () => void;
   onMenuOpen: () => void;
   onBorderChange?: (borderId: string | null, tier: BorderTier | null, color: string | null) => void;
@@ -56,6 +57,7 @@ export default function Navbar({
   activityFeedEnabled = false,
   avatarShopEnabled = false,
   isAdmin = false,
+  demoBannerHeight = 0,
   onLogout,
   onMenuOpen,
   onBorderChange,
@@ -147,7 +149,13 @@ export default function Navbar({
   const heroVisible = pathname === "/" && !scrolled;
 
   return (
-    <div className="fixed top-0 md:top-3 left-0 right-0 z-50 md:px-4 md:pointer-events-none">
+    <div
+      className={cn(
+        "fixed left-0 right-0 z-50 md:px-4 md:pointer-events-none transition-[top] duration-300",
+        demoBannerHeight === 0 && "top-0 md:top-3",
+      )}
+      style={demoBannerHeight > 0 ? { top: demoBannerHeight } : undefined}
+    >
       <nav
         className={cn(
           "md:pointer-events-auto md:w-fit md:mx-auto md:rounded-2xl transition-all duration-300",


### PR DESCRIPTION
## Summary
- Made `DemoBanner` fixed-position at `z-[51]` (above navbar's `z-50`) so it stays visible above the nav
- Navbar dynamically offsets its `top` by the banner's measured height via a new `demoBannerHeight` prop
- Content area adds matching `marginTop` so page content isn't hidden behind the banner + navbar stack

## Test plan
- [ ] Visit staging site while logged out — banner should appear above the navbar without overlapping
- [ ] Dismiss the banner — navbar and content should snap back to normal position
- [ ] Log in — banner should disappear and layout should be unaffected
- [ ] Test on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)