### PR TITLE
fix: sanitize full_name inputs to prevent stored XSS

### DIFF
--- a/src/app/(frontend)/(auth)/guest-setup/page.tsx
+++ b/src/app/(frontend)/(auth)/guest-setup/page.tsx
@@ -7,6 +7,7 @@ import { Button, Input } from "@/components/ui";
 import { PRESET_AVATARS } from "@/lib/constants/avatars";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
+import { sanitizeName } from "@/lib/utils/sanitize-name";
 
 export default function GuestSetupPage() {
   const router = useRouter();
@@ -36,7 +37,7 @@ export default function GuestSetupPage() {
 
     const { error: updateError } = await supabase.from("users").upsert({
       id: user.id,
-      full_name: displayName || "Adventurer",
+      full_name: sanitizeName(displayName) || "Adventurer",
       avatar_url: selectedAvatar,
       is_guest: true,
       role: "guest",

--- a/src/app/(frontend)/(auth)/signup/page.tsx
+++ b/src/app/(frontend)/(auth)/signup/page.tsx
@@ -11,6 +11,7 @@ import { STRAVA_AUTH_URL, STRAVA_SCOPES } from "@/lib/strava/constants";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 import { generateUsername } from "@/lib/utils/generate-username";
+import { sanitizeName } from "@/lib/utils/sanitize-name";
 
 const USERNAME_REGEX = /^[a-z0-9._-]{3,30}$/;
 
@@ -132,7 +133,7 @@ function SignupForm() {
   const metadataRef = useRef<Record<string, string>>({});
 
   const buildMetadata = () => {
-    const metadata: Record<string, string> = { full_name: fullName.trim() };
+    const metadata: Record<string, string> = { full_name: sanitizeName(fullName) };
     return metadata;
   };
 

--- a/src/app/(frontend)/(participant)/welcome/[code]/WelcomeClient.tsx
+++ b/src/app/(frontend)/(participant)/welcome/[code]/WelcomeClient.tsx
@@ -15,6 +15,7 @@ import { STRAVA_AUTH_URL, STRAVA_SCOPES } from "@/lib/strava/constants";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 import { generateUsername } from "@/lib/utils/generate-username";
+import { sanitizeName } from "@/lib/utils/sanitize-name";
 
 const USERNAME_REGEX = /^[a-z0-9._-]{3,30}$/;
 const CODE_LENGTH = 6;
@@ -263,7 +264,7 @@ function InlineAuthForm({
   }, []);
 
   const handlePostSignup = async (userId: string) => {
-    const trimmedName = fullName.trim();
+    const trimmedName = sanitizeName(fullName);
     if (trimmedName) {
       await supabase.from("users").update({ full_name: trimmedName }).eq("id", userId);
     }

--- a/src/app/(frontend)/api/bookings/route.ts
+++ b/src/app/(frontend)/api/bookings/route.ts
@@ -7,6 +7,7 @@ import { findOverlappingEvent, formatOverlapDate } from "@/lib/events/overlap";
 import { createNotification, createNotifications } from "@/lib/notifications/create";
 import { uploadToR2 } from "@/lib/r2";
 import { createClient } from "@/lib/supabase/server";
+import { sanitizeName } from "@/lib/utils/sanitize-name";
 
 interface CompanionInput {
   full_name: string;
@@ -403,7 +404,7 @@ export async function POST(request: Request) {
       return {
         id,
         booking_id: bookingId,
-        full_name: c.full_name.trim(),
+        full_name: sanitizeName(c.full_name),
         phone: c.phone || null,
         status: companionStatus,
         qr_code: generateQr ? `eventtara:checkin:${eventId}:companion:${id}` : null,

--- a/src/app/(frontend)/auth/callback/route.ts
+++ b/src/app/(frontend)/auth/callback/route.ts
@@ -4,6 +4,7 @@ import { isAvatarShopEnabled } from "@/lib/cms/cached";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { awardTokens } from "@/lib/tokens/award";
 import { TOKEN_REWARDS } from "@/lib/tokens/constants";
+import { sanitizeName } from "@/lib/utils/sanitize-name";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -30,7 +31,7 @@ export async function GET(request: Request) {
           {
             id: user.id,
             email: user.email ?? null,
-            full_name: preferredName ?? "User",
+            full_name: sanitizeName(preferredName ?? "User"),
             avatar_url: meta?.avatar_url ?? meta?.picture ?? null,
             role: "user",
           },

--- a/src/components/booking/AuthBookingModal.tsx
+++ b/src/components/booking/AuthBookingModal.tsx
@@ -15,6 +15,7 @@ import {
 import { Button, OtpCodeInput } from "@/components/ui";
 import { STRAVA_AUTH_URL, STRAVA_SCOPES } from "@/lib/strava/constants";
 import { createClient } from "@/lib/supabase/client";
+import { sanitizeName } from "@/lib/utils/sanitize-name";
 
 type ModalState = "form" | "verify-code" | "success";
 type AuthMode = "signin" | "signup";
@@ -173,7 +174,7 @@ export default function AuthBookingModal({
     e.preventDefault();
     setError("");
 
-    const trimmedName = fullName.trim();
+    const trimmedName = sanitizeName(fullName);
     if (!trimmedName) {
       setError("Please enter your name.");
       return;

--- a/src/lib/utils/__tests__/sanitize-name.test.ts
+++ b/src/lib/utils/__tests__/sanitize-name.test.ts
@@ -1,0 +1,31 @@
+import { sanitizeName } from "../sanitize-name";
+
+describe("sanitizeName", () => {
+  test("returns plain text unchanged", () => {
+    expect(sanitizeName("James Soo")).toBe("James Soo");
+  });
+
+  test("strips script tags", () => {
+    expect(sanitizeName('"><script>alert(1)</script>')).toBe('"alert(1)');
+  });
+
+  test("strips img onerror payloads", () => {
+    expect(sanitizeName('"><img src="x" onerror=alert(1)>')).toBe('"');
+  });
+
+  test("removes stray angle brackets", () => {
+    expect(sanitizeName("name<>test")).toBe("nametest");
+  });
+
+  test("trims whitespace", () => {
+    expect(sanitizeName("  John Doe  ")).toBe("John Doe");
+  });
+
+  test("returns empty string for tag-only input", () => {
+    expect(sanitizeName("<script>alert(1)</script>")).toBe("alert(1)");
+  });
+
+  test("handles empty string", () => {
+    expect(sanitizeName("")).toBe("");
+  });
+});

--- a/src/lib/utils/sanitize-name.ts
+++ b/src/lib/utils/sanitize-name.ts
@@ -1,0 +1,10 @@
+/**
+ * Strips HTML tags and trims a plain-text name field.
+ * Lightweight alternative to sanitize-html for simple text inputs.
+ */
+export function sanitizeName(value: string): string {
+  return value
+    .replaceAll(/<[^>]*>/g, "")
+    .replaceAll(/[<>]/g, "")
+    .trim();
+}


### PR DESCRIPTION
## Summary
- Added `sanitizeName()` utility (`src/lib/utils/sanitize-name.ts`) that strips HTML tags and stray angle brackets from plain-text name inputs
- Applied at all 6 write points for `full_name`: guest-setup, signup, welcome flow, auth callback, booking modal, and companion booking API
- Added unit tests covering script tags, img onerror payloads, stray brackets, whitespace, and edge cases

## Context
Pen testers injected XSS payloads (`<script>alert(1)</script>`, `<img onerror=...>`) into the `full_name` field. React's JSX escaping prevents execution on render, but storing raw payloads in the DB is a defense-in-depth concern — especially if data is ever consumed outside React (emails, exports, APIs).

Note: `username` was already safe — validated by `USERNAME_REGEX` (`/^[a-z0-9._-]{3,30}$/`).

## Test plan
- [ ] Run `pnpm test -- --run src/lib/utils/__tests__/sanitize-name.test.ts` — 7 tests pass
- [ ] Sign up with `<script>alert(1)</script>` as full name — should be stripped to `alert(1)`
- [ ] Guest setup with HTML in display name — stored without tags
- [ ] Book with companion name containing HTML — stripped on insert

🤖 Generated with [Claude Code](https://claude.com/claude-code)