### PR TITLE
style: default to dark mode and warm up light mode backgrounds

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100 antialiased;
+    @apply bg-stone-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 antialiased;
   }
 }
 
@@ -46,7 +46,7 @@
     @apply border-2 border-lime-500 text-lime-600 dark:text-lime-400 hover:bg-lime-50 dark:hover:bg-lime-950 font-semibold py-3 px-6 rounded-xl transition-colors;
   }
   .card {
-    @apply bg-white dark:bg-gray-900 rounded-2xl shadow-md dark:shadow-gray-950/30 hover:shadow-lg transition-shadow;
+    @apply bg-white dark:bg-gray-900 rounded-2xl shadow-md shadow-stone-200/50 dark:shadow-gray-950/30 hover:shadow-lg transition-shadow;
   }
 }
 

--- a/src/components/landing/HostEventLink.tsx
+++ b/src/components/landing/HostEventLink.tsx
@@ -4,7 +4,7 @@ export default function HostEventLink() {
   return (
     <Link
       href="/clubs/new"
-      className="inline-flex items-center justify-center font-semibold rounded-xl text-base sm:text-lg py-3.5 px-6 sm:py-4 sm:px-8 border-2 border-gray-300 dark:border-slate-600 text-gray-600 dark:text-gray-300 hover:border-lime-500 hover:text-lime-600 dark:hover:text-lime-400 transition-colors"
+      className="inline-flex items-center justify-center font-semibold rounded-xl text-base sm:text-lg py-3.5 px-6 sm:py-4 sm:px-8 border-2 border-white/40 text-white hover:border-lime-500 hover:text-lime-600 dark:hover:border-lime-400 dark:hover:text-lime-400 transition-colors"
     >
       Start a Club
     </Link>

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -69,7 +69,7 @@ export default function MobileDrawer({
       {/* Drawer panel */}
       <div
         ref={drawerRef}
-        className={`fixed top-0 right-0 z-50 h-full w-4/5 max-w-sm bg-white dark:bg-gray-900 shadow-xl transition-transform duration-300 ease-out md:hidden ${
+        className={`fixed top-0 right-0 z-50 h-full w-4/5 max-w-sm bg-stone-50 dark:bg-gray-900 shadow-xl transition-transform duration-300 ease-out md:hidden ${
           open ? "translate-x-0" : "translate-x-full"
         }`}
       >

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -134,7 +134,7 @@ export default function MobileNav({
   return (
     <nav
       className={cn(
-        "md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md border-t border-gray-200 dark:border-gray-800 safe-area-bottom transition-transform duration-300 ease-in-out",
+        "md:hidden fixed bottom-0 left-0 right-0 z-50 bg-stone-50/95 dark:bg-gray-900/95 backdrop-blur-md border-t border-stone-200 dark:border-gray-800 safe-area-bottom transition-transform duration-300 ease-in-out",
         (keyboardOpen || hidden) && "translate-y-full",
       )}
     >

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -161,7 +161,7 @@ export default function Navbar({
           "md:pointer-events-auto md:w-fit md:mx-auto md:rounded-2xl transition-all duration-300",
           scrolled || pathname !== "/"
             ? // Scrolled or non-homepage: solid / frosted glass
-              "bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 md:bg-white/90 md:dark:bg-gray-900/90 md:backdrop-blur-md md:border md:border-gray-200/80 md:dark:border-gray-700/80 md:shadow-lg md:shadow-black/5 md:dark:shadow-black/20"
+              "bg-stone-50 dark:bg-gray-900 border-b border-stone-200 dark:border-gray-800 md:bg-stone-50/90 md:dark:bg-gray-900/90 md:backdrop-blur-md md:border md:border-stone-200/80 md:dark:border-gray-700/80 md:shadow-lg md:shadow-black/5 md:dark:shadow-black/20"
             : // Homepage not scrolled: transparent
               "bg-transparent border-b border-transparent md:bg-white/5 md:backdrop-blur-sm md:border md:border-white/10",
         )}

--- a/src/components/layout/ThemeProvider.tsx
+++ b/src/components/layout/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import { type ThemeProviderProps } from "next-themes";
 
 export default function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
-    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem {...props}>
+    <NextThemesProvider attribute="class" defaultTheme="dark" enableSystem {...props}>
       {children}
     </NextThemesProvider>
   );


### PR DESCRIPTION
## Summary
- Default theme changed from `system` to `dark` for a more pleasing first impression
- Replaced stark white (`#fff`) backgrounds with warm `stone-50` (`#fafaf9`) across body, navbar, mobile nav, mobile drawer
- Fixed hero "Start a Club" button visibility — now uses white text/border so it's readable on the dark overlay
- Softened card shadows in light mode with `stone-200/50` tint

## Test plan
- [ ] Visit site in incognito — should default to dark mode
- [ ] Toggle to light mode — backgrounds should be warm off-white, not stark white
- [ ] Check navbar, mobile bottom nav, and mobile drawer in light mode
- [ ] Verify hero "Start a Club" button is clearly visible in both themes
- [ ] Toggle back to dark mode — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)