### PR TITLE
feat(feed): show new user signups in activity feed

### DIFF
--- a/src/app/(frontend)/(participant)/post/[id]/page.tsx
+++ b/src/app/(frontend)/(participant)/post/[id]/page.tsx
@@ -58,6 +58,7 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
     { data: review },
     { data: newClub },
     { data: newEvent },
+    { data: newUser },
   ] = await Promise.all([
     supabase
       .from("bookings")
@@ -101,6 +102,13 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
       .eq("id", id)
       .eq("status", "published")
       .eq("clubs.club_members.role", "owner")
+      .maybeSingle(),
+    // User by id — non-guest
+    supabase
+      .from("users")
+      .select("id, full_name, avatar_url, created_at")
+      .eq("id", id)
+      .eq("is_guest", false)
       .maybeSingle(),
   ]);
 
@@ -263,6 +271,20 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
         timestamp: newEvent.created_at,
       };
     }
+  } else if (newUser) {
+    activity = {
+      id: newUser.id,
+      activityType: "new_user",
+      userId: newUser.id,
+      text: "joined EventTara",
+      contextImageUrl: newUser.avatar_url || null,
+      ...nullBadge,
+      ...nullBorder,
+      ...nullReview,
+      ...nullPhoto,
+      ...nullClubEvent,
+      timestamp: newUser.created_at,
+    };
   }
 
   if (!activity) notFound();

--- a/src/app/(frontend)/api/feed/route.ts
+++ b/src/app/(frontend)/api/feed/route.ts
@@ -58,6 +58,7 @@ export async function GET(request: Request) {
     { data: reposts },
     { data: newClubs },
     { data: newEvents },
+    { data: newUsers },
   ] = await Promise.all([
     supabase
       .from("bookings")
@@ -131,6 +132,13 @@ export async function GET(request: Request) {
       .eq("is_demo", false)
       .eq("clubs.is_demo", false)
       .eq("clubs.club_members.role", "owner")
+      .order("created_at", { ascending: false })
+      .limit(fetchLimit),
+    // New users: non-guest signups
+    supabase
+      .from("users")
+      .select("id, full_name, avatar_url, created_at")
+      .eq("is_guest", false)
       .order("created_at", { ascending: false })
       .limit(fetchLimit),
   ]);
@@ -319,6 +327,22 @@ export async function GET(request: Request) {
       eventId: ev.id,
       eventTitle: ev.title,
       timestamp: ev.created_at,
+    });
+  }
+
+  for (const u of newUsers || []) {
+    activities.push({
+      id: u.id,
+      activityType: "new_user",
+      userId: u.id,
+      text: "joined EventTara",
+      contextImageUrl: u.avatar_url || null,
+      ...nullBadge,
+      ...nullBorder,
+      ...nullReview,
+      ...nullPhoto,
+      ...nullClubEvent,
+      timestamp: u.created_at,
     });
   }
 

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -136,12 +136,16 @@ export default function FeedCard({ item, isAuthenticated, currentUserId }: FeedC
         {/* New event showcase */}
         {item.activityType === "new_event" && <EventShowcase item={item} />}
 
-        {/* Context image (non-badge/border/photo/club/event activities) */}
+        {/* New user showcase */}
+        {item.activityType === "new_user" && <NewUserShowcase item={item} />}
+
+        {/* Context image (non-badge/border/photo/club/event/user activities) */}
         {item.activityType !== "badge" &&
           item.activityType !== "border" &&
           item.activityType !== "photo" &&
           item.activityType !== "new_club" &&
           item.activityType !== "new_event" &&
+          item.activityType !== "new_user" &&
           item.contextImageUrl && (
             <div className="relative w-full h-40 rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800">
               <Image
@@ -292,6 +296,29 @@ function EventShowcase({ item }: { item: FeedItem }) {
         )}
         {item.eventId && (
           <p className="text-xs text-forest-600 dark:text-forest-400 mt-1">View event →</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function NewUserShowcase({ item }: { item: FeedItem }) {
+  return (
+    <div className="flex items-center gap-3 p-3 rounded-xl bg-forest-50 dark:bg-forest-950/30 border border-forest-100 dark:border-forest-900/50">
+      <div className="w-10 h-10 rounded-full bg-forest-100 dark:bg-forest-900/50 flex items-center justify-center shrink-0">
+        <span className="text-forest-600 dark:text-forest-400 text-base">👋</span>
+      </div>
+      <div className="min-w-0">
+        <p className="font-semibold text-gray-900 dark:text-white text-sm truncate">
+          Welcome to EventTara!
+        </p>
+        {item.userUsername && (
+          <p className="text-xs text-forest-600 dark:text-forest-400">
+            @{item.userUsername} is a new adventurer
+          </p>
+        )}
+        {!item.userUsername && (
+          <p className="text-xs text-forest-600 dark:text-forest-400">New adventurer</p>
         )}
       </div>
     </div>

--- a/src/lib/feed/types.ts
+++ b/src/lib/feed/types.ts
@@ -9,7 +9,8 @@ export type ActivityType =
   | "review"
   | "photo"
   | "new_club"
-  | "new_event";
+  | "new_event"
+  | "new_user";
 export type EmojiType = "heart";
 
 export const EMOJI_ICON = "💚";

--- a/src/lib/notifications/resolve-activity-owner.ts
+++ b/src/lib/notifications/resolve-activity-owner.ts
@@ -12,6 +12,7 @@ const TABLE_MAP: Record<ActivityType, string | null> = {
   photo: "event_photos",
   new_club: null,
   new_event: null,
+  new_user: null,
 };
 
 /**
@@ -23,6 +24,11 @@ export async function resolveActivityOwner(
   activityType: ActivityType,
   activityId: string,
 ): Promise<string | null> {
+  // For new_user, the activity ID is the user ID itself
+  if (activityType === "new_user") {
+    return activityId;
+  }
+
   // For clubs, resolve owner via club_members
   if (activityType === "new_club") {
     const { data } = await supabase

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -861,7 +861,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id: string;
           text: string;
           created_at: string;
@@ -877,7 +878,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id: string;
           text: string;
           created_at?: string;
@@ -893,7 +895,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id?: string;
           text?: string;
           created_at?: string;
@@ -933,7 +936,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id: string;
           emoji: "heart";
           created_at: string;
@@ -949,7 +953,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id: string;
           emoji: "heart";
           created_at?: string;
@@ -965,7 +970,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id?: string;
           emoji?: "heart";
           created_at?: string;
@@ -984,7 +990,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id: string;
           created_at: string;
         };
@@ -999,7 +1006,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id: string;
           created_at?: string;
         };
@@ -1014,7 +1022,8 @@ export interface Database {
             | "review"
             | "photo"
             | "new_club"
-            | "new_event";
+            | "new_event"
+            | "new_user";
           activity_id?: string;
           created_at?: string;
         };

--- a/supabase/migrations/20260415_feed_new_user_type.sql
+++ b/supabase/migrations/20260415_feed_new_user_type.sql
@@ -1,0 +1,16 @@
+-- Add 'new_user' to activity_type CHECK constraints on feed tables
+
+ALTER TABLE feed_reactions
+  DROP CONSTRAINT feed_reactions_activity_type_check,
+  ADD CONSTRAINT feed_reactions_activity_type_check
+    CHECK (activity_type IN ('booking', 'checkin', 'badge', 'border', 'review', 'photo', 'new_club', 'new_event', 'new_user'));
+
+ALTER TABLE feed_comments
+  DROP CONSTRAINT feed_comments_activity_type_check,
+  ADD CONSTRAINT feed_comments_activity_type_check
+    CHECK (activity_type IN ('booking', 'checkin', 'badge', 'border', 'review', 'photo', 'new_club', 'new_event', 'new_user'));
+
+ALTER TABLE feed_reposts
+  DROP CONSTRAINT feed_reposts_activity_type_check,
+  ADD CONSTRAINT feed_reposts_activity_type_check
+    CHECK (activity_type IN ('booking', 'checkin', 'badge', 'border', 'review', 'photo', 'new_club', 'new_event', 'new_user'));


### PR DESCRIPTION
## Summary
- Added `new_user` activity type to the feed so non-guest signups appear as "joined EventTara" entries
- Added a `NewUserShowcase` welcome card (wave emoji + username) in the feed
- Updated the single post page, Supabase types, notification resolver, and feed tables CHECK constraints
- Includes SQL migration (`20260415_feed_new_user_type.sql`) to add `new_user` to `feed_reactions`, `feed_comments`, and `feed_reposts` constraints

## Test plan
- [ ] Sign up with a new non-guest account and verify it appears in `/feed`
- [ ] Verify guest signups do **not** appear in the feed
- [ ] Click a new_user feed card to verify `/post/[id]` renders correctly
- [ ] Like, comment, and repost a new_user activity to verify interactions work
- [ ] Run the SQL migration and confirm no constraint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)