### PR TITLE
fix(feed): hide guest/incomplete accounts from activity feed

### DIFF
--- a/src/app/(frontend)/api/feed/route.ts
+++ b/src/app/(frontend)/api/feed/route.ts
@@ -134,11 +134,12 @@ export async function GET(request: Request) {
       .eq("clubs.club_members.role", "owner")
       .order("created_at", { ascending: false })
       .limit(fetchLimit),
-    // New users: non-guest signups
+    // New users: non-guest signups with completed profiles
     supabase
       .from("users")
       .select("id, full_name, avatar_url, created_at")
       .eq("is_guest", false)
+      .not("username", "is", null)
       .order("created_at", { ascending: false })
       .limit(fetchLimit),
   ]);

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -354,7 +354,11 @@ export default function Navbar({
             ) : (
               <div className="flex items-center gap-3">
                 <NavLink href="/login">
-                  <Button variant="ghost" size="sm">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={heroVisible ? "text-white hover:text-white hover:bg-white/10" : ""}
+                  >
                     Sign In
                   </Button>
                 </NavLink>


### PR DESCRIPTION
## Summary
- Filter out users without a username from "joined EventTara" feed entries
- These incomplete accounts (guest-converted or unfinished signups) were showing as generic "Adventurer" cards

## Test plan
- [ ] Visit `/feed` and verify no "Adventurer" entries without usernames appear
- [ ] Verify real users with completed profiles still show in the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)