### PR TITLE
fix: add missing 950 color shades for dark mode across app

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,7 @@ const config: Config = {
           700: "#155e75",
           800: "#164e63",
           900: "#134e4a",
+          950: "#0a2f2b",
         },
         forest: {
           50: "#f0faf4",
@@ -35,6 +36,7 @@ const config: Config = {
           700: "#1e623d",
           800: "#1b4e33",
           900: "#17402b",
+          950: "#0f2b1c",
         },
         golden: {
           50: "#fffdf0",
@@ -47,6 +49,7 @@ const config: Config = {
           700: "#a96c00",
           800: "#8a5500",
           900: "#724600",
+          950: "#4a2d00",
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- Add `teal-950` (`#0a2f2b`), `forest-950` (`#0f2b1c`), and `golden-950` (`#4a2d00`) to Tailwind config
- All three custom color palettes were missing 950 shades, causing `dark:bg-*-950` classes to have no effect — leaving light backgrounds in dark mode with unreadable text
- Affects 18 components: feed cards, profile stats, badge awarder, guide pages, event review, weather grid, border picker, itinerary manager, waitlist section, club manager, forum, and QR batch manager

## Test plan
- [ ] Visit `/feed` in dark mode — verify new user, event, and club showcase cards have dark backgrounds
- [ ] Visit `/profile` in dark mode — verify stats cards have dark backgrounds
- [ ] Visit `/guides/[id]` in dark mode — verify rating/stats cards render correctly
- [ ] Spot-check other affected pages (dashboard, border picker, waitlist) in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)